### PR TITLE
Use controller-runtime client for secret content retrieval

### DIFF
--- a/pkg/util/crud_test.go
+++ b/pkg/util/crud_test.go
@@ -42,9 +42,8 @@ const (
 var (
 	ctx       = context.Background()
 	errorBoom = errors.New("boom")
-	meta      = metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid}
 	service   = &corev1.Service{
-		ObjectMeta: meta,
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid},
 		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
 	}
 )


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
K8s go-client is not directly available everywhere anymore and for the sake of consistency I think we should use controller-runtime client wherever possible.

Needed for the merge conflict fix of https://github.com/crossplaneio/crossplane/pull/699

-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run ~~`make reviewable`~~ `make` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml