### PR TITLE
Make writeConnectionSecretToRef optional

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -88,7 +88,7 @@ func NewAPIManagedConnectionPropagator(c client.Client, t runtime.ObjectTyper) *
 
 // PropagateConnection details from the supplied resource to the supplied claim.
 func (a *APIManagedConnectionPropagator) PropagateConnection(ctx context.Context, cm Claim, mg Managed) error {
-	// Either this resourace does not expose a connection secret, or this claim
+	// Either this resource does not expose a connection secret, or this claim
 	// does not want one.
 	if mg.GetWriteConnectionSecretToReference().Name == "" || cm.GetWriteConnectionSecretToReference().Name == "" {
 		return nil

--- a/pkg/resource/publisher.go
+++ b/pkg/resource/publisher.go
@@ -68,6 +68,11 @@ func NewAPISecretPublisher(c client.Client, ot runtime.ObjectTyper) *APISecretPu
 // the supplied Managed resource. Applying is a no-op if the secret already
 // exists with the supplied ConnectionDetails.
 func (a *APISecretPublisher) PublishConnection(ctx context.Context, mg Managed, c ConnectionDetails) error {
+	// This resource does not want to expose a connection secret.
+	if mg.GetWriteConnectionSecretToReference().Name == "" {
+		return nil
+	}
+
 	s := ConnectionSecretFor(mg, MustGetKind(mg, a.typer))
 
 	err := util.CreateOrUpdate(ctx, a.client, s, func() error {

--- a/pkg/resource/publisher_test.go
+++ b/pkg/resource/publisher_test.go
@@ -138,6 +138,12 @@ func TestAPISecretPublisher(t *testing.T) {
 		args   args
 		want   error
 	}{
+		"ResourceDoesNotPublishSecret": {
+			args: args{
+				ctx: context.Background(),
+				mg:  &MockManaged{},
+			},
+		},
 		"ManagedSecretConflictError": {
 			fields: fields{
 				client: &test.MockClient{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Fixes https://github.com/crossplaneio/crossplane/issues/719

The resource claim reconciler (and API definitions) consider writeConnectionSecretToRef to be optional, but the managed resource reconciler fails if it is not specified. This change aligns the codebase on the reference being optional. Managed resources that do not specify a secret reference will provision successfully without publishing their connection details to a secret.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml