### PR TITLE
Allow both resource claims and managed resources to pass the class kind predicate

### DIFF
--- a/pkg/resource/claim_reconciler.go
+++ b/pkg/resource/claim_reconciler.go
@@ -57,6 +57,10 @@ var log = logging.Logger.WithName("controller")
 // A ClaimKind contains the type metadata for a kind of resource claim.
 type ClaimKind schema.GroupVersionKind
 
+// A NonPortableClassKind contains the type metadata for a kind of
+// non-portable resource class.
+type NonPortableClassKind schema.GroupVersionKind
+
 // A ClassKinds contains the type metadata for a kind of resource class.
 type ClassKinds struct {
 	Portable    schema.GroupVersionKind

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -61,6 +61,13 @@ func TestHasClassReferenceKinds(t *testing.T) {
 	mockClaimWithRef := MockClaim{}
 	mockClaimWithRef.SetPortableClassReference(&corev1.LocalObjectReference{Name: "cool-portable"})
 
+	mockManagedWithRef := MockManaged{}
+	mockManagedWithRef.SetNonPortableClassReference(&corev1.ObjectReference{
+		APIVersion: MockGVK(&MockNonPortableClass{}).GroupVersion().String(),
+		Kind:       MockGVK(&MockNonPortableClass{}).Kind,
+		Name:       "cool-nonportable",
+	})
+
 	cases := map[string]struct {
 		obj  runtime.Object
 		c    client.Client
@@ -115,7 +122,7 @@ func TestHasClassReferenceKinds(t *testing.T) {
 			kind: ck,
 			want: false,
 		},
-		"HasCorrect": {
+		"HasCorrectIndirectClass": {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
 					switch o := o.(type) {
@@ -135,6 +142,12 @@ func TestHasClassReferenceKinds(t *testing.T) {
 			},
 			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
 			obj:  &mockClaimWithRef,
+			kind: ck,
+			want: true,
+		},
+		"HasCorrectDirectClass": {
+			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
+			obj:  &mockManagedWithRef,
 			kind: ck,
 			want: true,
 		},

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -30,6 +30,11 @@ import (
 
 type mockObject struct{ runtime.Object }
 
+type mockReferencer struct {
+	runtime.Object
+	*MockPortableClassReferencer
+}
+
 type mockPortableClassReferencer struct {
 	runtime.Object
 	ref *corev1.LocalObjectReference
@@ -63,10 +68,17 @@ func TestHasClassReferenceKinds(t *testing.T) {
 		kind ClassKinds
 		want bool
 	}{
-		"NotAClaim": {
+		"NotAClassReferencer": {
 			c:    &test.MockClient{},
 			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
 			obj:  &mockObject{},
+			kind: ck,
+			want: false,
+		},
+		"NotANamespacer": {
+			c:    &test.MockClient{},
+			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
+			obj:  &mockReferencer{MockPortableClassReferencer: &MockPortableClassReferencer{Ref: &corev1.LocalObjectReference{}}},
 			kind: ck,
 			want: false,
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
It turns out both our watches use the same predicate and apply it to the watched kind, not the kind that actually gets enqueued.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml