### PR TITLE
Fix support for static provisioning

### DIFF
--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -67,6 +67,10 @@ func HasDirectClassReferenceKind(k NonPortableClassKind) PredicateFn {
 			return false
 		}
 
+		if r.GetNonPortableClassReference() == nil {
+			return false
+		}
+
 		return r.GetNonPortableClassReference().GroupVersionKind() == schema.GroupVersionKind(k)
 	}
 }

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -126,9 +126,9 @@ func HasIndirectClassReferenceKind(c client.Client, oc runtime.ObjectCreater, k 
 	}
 }
 
-// NoPortableClassReference accepts ResourceClaims that do not reference a
+// HasNoPortableClassReference accepts ResourceClaims that do not reference a
 // specific portable class
-func NoPortableClassReference() PredicateFn {
+func HasNoPortableClassReference() PredicateFn {
 	return func(obj runtime.Object) bool {
 		cr, ok := obj.(PortableClassReferencer)
 		if !ok {
@@ -138,9 +138,9 @@ func NoPortableClassReference() PredicateFn {
 	}
 }
 
-// NoManagedResourceReference accepts ResourceClaims that do not reference a
+// HasNoManagedResourceReference accepts ResourceClaims that do not reference a
 // specific Managed Resource
-func NoManagedResourceReference() PredicateFn {
+func HasNoManagedResourceReference() PredicateFn {
 	return func(obj runtime.Object) bool {
 		cr, ok := obj.(ManagedResourceReferencer)
 		if !ok {

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -61,13 +61,6 @@ func TestHasClassReferenceKinds(t *testing.T) {
 	mockClaimWithRef := MockClaim{}
 	mockClaimWithRef.SetPortableClassReference(&corev1.LocalObjectReference{Name: "cool-portable"})
 
-	mockManagedWithRef := MockManaged{}
-	mockManagedWithRef.SetNonPortableClassReference(&corev1.ObjectReference{
-		APIVersion: MockGVK(&MockNonPortableClass{}).GroupVersion().String(),
-		Kind:       MockGVK(&MockNonPortableClass{}).Kind,
-		Name:       "cool-nonportable",
-	})
-
 	cases := map[string]struct {
 		obj  runtime.Object
 		c    client.Client
@@ -145,9 +138,23 @@ func TestHasClassReferenceKinds(t *testing.T) {
 			kind: ck,
 			want: true,
 		},
-		"HasCorrectDirectClass": {
+		"HasNoDirectClass": {
 			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
-			obj:  &mockManagedWithRef,
+			obj:  &MockManaged{},
+			kind: ck,
+			want: false,
+		},
+		"HasCorrectDirectClass": {
+			s: MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
+			obj: &MockManaged{
+				MockNonPortableClassReferencer: MockNonPortableClassReferencer{
+					Ref: &corev1.ObjectReference{
+						APIVersion: MockGVK(&MockNonPortableClass{}).GroupVersion().String(),
+						Kind:       MockGVK(&MockNonPortableClass{}).Kind,
+						Name:       "cool-nonportable",
+					},
+				},
+			},
 			kind: ck,
 			want: true,
 		},

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -242,7 +242,7 @@ func TestHasIndirectClassReferenceKind(t *testing.T) {
 	}
 }
 
-func TestNoPortableClassReference(t *testing.T) {
+func TestHasNoPortableClassReference(t *testing.T) {
 	cases := map[string]struct {
 		obj  runtime.Object
 		want bool
@@ -262,7 +262,7 @@ func TestNoPortableClassReference(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := NoPortableClassReference()(tc.obj)
+			got := HasNoPortableClassReference()(tc.obj)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NoClassReference(...): -want, +got:\n%s", diff)
 			}
@@ -270,7 +270,7 @@ func TestNoPortableClassReference(t *testing.T) {
 	}
 }
 
-func TestNoMangedResourceReference(t *testing.T) {
+func TestHasNoMangedResourceReference(t *testing.T) {
 	cases := map[string]struct {
 		obj  runtime.Object
 		want bool
@@ -290,7 +290,7 @@ func TestNoMangedResourceReference(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := NoManagedResourceReference()(tc.obj)
+			got := HasNoManagedResourceReference()(tc.obj)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NoManagedResourecReference(...): -want, +got:\n%s", diff)
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This PR fixes support for managed resources that do not reference a class. Controllers built against crossplane-runtime will currently panic if they encounter a managed resource without a class reference. Any dynamically provisioned managed resource will have a class reference, but this breaks the static provisioning workflow in which a managed resource is explicitly provisioned, then later claimed.

The PR also fixes watch predicates for the static binding flow We currently support dynamic provisioning in the resource claim reconciler by using a watch predicate that allows either managed resources that directly reference a non-portable resource class of a given kind, or resource claims that reference a non-portable resource class of a given kind indirectly via a portable resource class.

To support static provisioning (i.e. explicitly claiming an existing managed resource) we must also allow resource claims that explicitly reference a managed resource. Writing one predicate to do all of this was getting cumbersome, so I have refactored the predicate interface a little.

This PR will require additional PRs to update Crossplane core, and each stack.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml