### PR TITLE
predicates: remove deprecated hasdirectclassreferencekind

### DIFF
--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -81,24 +81,6 @@ func IsManagedKind(k ManagedKind, ot runtime.ObjectTyper) PredicateFn {
 	}
 }
 
-// HasDirectClassReferenceKind accepts objects that reference the supplied
-// non-portable class kind directly. It is deprecated - use IsManagedKind
-// instead.
-func HasDirectClassReferenceKind(k NonPortableClassKind) PredicateFn {
-	return func(obj runtime.Object) bool {
-		r, ok := obj.(NonPortableClassReferencer)
-		if !ok {
-			return false
-		}
-
-		if r.GetNonPortableClassReference() == nil {
-			return false
-		}
-
-		return r.GetNonPortableClassReference().GroupVersionKind() == schema.GroupVersionKind(k)
-	}
-}
-
 // HasIndirectClassReferenceKind accepts namespaced objects that reference the
 // supplied non-portable class kind via the supplied portable class kind.
 func HasIndirectClassReferenceKind(c client.Client, oc runtime.ObjectCreater, k ClassKinds) PredicateFn {

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -140,51 +140,6 @@ func TestIsManagedKind(t *testing.T) {
 	}
 }
 
-func TestHasDirectClassReferenceKind(t *testing.T) {
-	cases := map[string]struct {
-		obj  runtime.Object
-		c    client.Client
-		s    runtime.ObjectCreater
-		kind NonPortableClassKind
-		want bool
-	}{
-		"NotAClassReferencer": {
-			c:    &test.MockClient{},
-			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
-			kind: NonPortableClassKind(MockGVK(&MockNonPortableClass{})),
-			want: false,
-		},
-		"HasNoDirectClass": {
-			s:    MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
-			obj:  &MockManaged{},
-			kind: NonPortableClassKind(MockGVK(&MockNonPortableClass{})),
-			want: false,
-		},
-		"HasCorrectDirectClass": {
-			s: MockSchemeWith(&MockClaim{}, &MockPortableClass{}, &MockNonPortableClass{}),
-			obj: &MockManaged{
-				MockNonPortableClassReferencer: MockNonPortableClassReferencer{
-					Ref: &corev1.ObjectReference{
-						APIVersion: MockGVK(&MockNonPortableClass{}).GroupVersion().String(),
-						Kind:       MockGVK(&MockNonPortableClass{}).Kind,
-					},
-				},
-			},
-			kind: NonPortableClassKind(MockGVK(&MockNonPortableClass{})),
-			want: true,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := HasDirectClassReferenceKind(tc.kind)(tc.obj)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("HasDirectClassReferenceKind(...): -want, +got:\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestHasIndirectClassReferenceKind(t *testing.T) {
 	errUnexpected := errors.New("unexpected object type")
 


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Pending merge of PR's:
- crossplaneio/stack-azure#21
- crossplaneio/stack-aws#25
- crossplaneio/stack-gcp#37

Fixes #33 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml