### PR TITLE
namespace-name scheme for managed resources

### DIFF
--- a/pkg/resource/configurator_test.go
+++ b/pkg/resource/configurator_test.go
@@ -18,8 +18,6 @@ package resource
 
 import (
 	"context"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -103,6 +101,8 @@ func TestConfiguratorChain(t *testing.T) {
 
 func TestConfigureObjectMeta(t *testing.T) {
 	ns := "namespace"
+	claimName := "myclaim"
+	claimNS := "myclaimns"
 	uid := types.UID("definitely-a-uuid")
 
 	type args struct {
@@ -126,18 +126,19 @@ func TestConfigureObjectMeta(t *testing.T) {
 			typer: MockSchemeWith(&MockClaim{}),
 			args: args{
 				ctx: context.Background(),
-				cm:  &MockClaim{ObjectMeta: metav1.ObjectMeta{UID: uid}},
+				cm:  &MockClaim{ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: claimNS, UID: uid}},
 				cs:  &MockNonPortableClass{ObjectMeta: metav1.ObjectMeta{Namespace: ns}},
 				mg:  &MockManaged{},
 			},
 			want: want{
 				mg: &MockManaged{ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
-					Name:      strings.ToLower(reflect.TypeOf(MockClaim{}).Name() + "-" + string(uid)),
+					Namespace:    ns,
+					GenerateName: claimNS + "-" + claimName + "-",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: MockGVK(&MockClaim{}).GroupVersion().String(),
 						Kind:       MockGVK(&MockClaim{}).Kind,
 						UID:        uid,
+						Name:       claimName,
 					}},
 				}},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

This PR changes the existing ObjectMetaConfigurator so that it will set the `GenerateName` field of the managed resource to `<claim ns>-<claim name>-`, which will have api-server name the managed resource as `<claim ns>-<claim name>-<5 char rand string>`. Addresses the new naming scheme in https://github.com/crossplaneio/crossplane/blob/c8ae09bc1c3befbc7ec7b96a37c3f729975d5b92/design/one-pager-managed-resource-api-design.md#custom-resource-instance-name

All claim reconcilers who use this configurator will be creating resource with the new naming scheme but existing CR instances shouldn't be affected.

Tested manually. Links will be updated once one-pager is merged.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml