### PR TITLE
Add UnavailableWithMessage condition helper

### DIFF
--- a/apis/core/v1alpha1/condition.go
+++ b/apis/core/v1alpha1/condition.go
@@ -207,6 +207,21 @@ func Unavailable() Condition {
 	}
 }
 
+// UnavailableWithMessage returns a condition that indicates the managed
+// resource is not currently available for use and contains the message returned
+// by the API. Unavailable should be set only when Crossplane expects the managed
+// resource to be available but knows it is not, for example because its API
+// reports it is unhealthy.
+func UnavailableWithMessage(msg string) Condition {
+	return Condition{
+		Type:               TypeReady,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonUnavailable,
+		Message:            msg,
+	}
+}
+
 // ReconcileSuccess returns a condition indicating that Crossplane successfully
 // completed the most recent reconciliation of the managed resource.
 func ReconcileSuccess() Condition {

--- a/apis/core/v1alpha1/condition.go
+++ b/apis/core/v1alpha1/condition.go
@@ -84,6 +84,13 @@ func (c Condition) Equal(other Condition) bool {
 		c.Message == other.Message
 }
 
+// WithMessage returns a condition by adding the provided message to existing
+// condition.
+func (c Condition) WithMessage(msg string) Condition {
+	c.Message = msg
+	return c
+}
+
 // NOTE(negz): Conditions are implemented as a slice rather than a map to comply
 // with Kubernetes API conventions. Ideally we'd comply by using a map that
 // marshalled to a JSON array, but doing so confuses the CRD schema generator.
@@ -204,21 +211,6 @@ func Unavailable() Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonUnavailable,
-	}
-}
-
-// UnavailableWithMessage returns a condition that indicates the managed
-// resource is not currently available for use and contains the message returned
-// by the API. Unavailable should be set only when Crossplane expects the managed
-// resource to be available but knows it is not, for example because its API
-// reports it is unhealthy.
-func UnavailableWithMessage(msg string) Condition {
-	return Condition{
-		Type:               TypeReady,
-		Status:             corev1.ConditionFalse,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonUnavailable,
-		Message:            msg,
 	}
 }
 

--- a/apis/core/v1alpha1/condition_test.go
+++ b/apis/core/v1alpha1/condition_test.go
@@ -152,3 +152,38 @@ func TestSetConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestConditionWithMessage(t *testing.T) {
+	testMsg := "Something went wrong on cloud side"
+	cases := map[string]struct {
+		c    Condition
+		msg  string
+		want Condition
+	}{
+		"MessageAdded": {
+			c:    Condition{Type: TypeReady, Reason: ReasonUnavailable},
+			msg:  testMsg,
+			want: Condition{Type: TypeReady, Reason: ReasonUnavailable, Message: testMsg},
+		},
+		"MessageChanged": {
+			c:    Condition{Type: TypeReady, Reason: ReasonUnavailable, Message: "Some other message"},
+			msg:  testMsg,
+			want: Condition{Type: TypeReady, Reason: ReasonUnavailable, Message: testMsg},
+		},
+		"MessageCleared": {
+			c:    Condition{Type: TypeReady, Reason: ReasonUnavailable, Message: testMsg},
+			msg:  "",
+			want: Condition{Type: TypeReady, Reason: ReasonUnavailable},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.c.WithMessage(tc.msg)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("a.Equal(b): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
Adds a helper function getting a Unavailable status condition with a message.
To be initially consumed by https://github.com/crossplaneio/stack-gcp/pull/44
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml