### PR TITLE
Use managed resource name as external name 

### DIFF
--- a/apis/core/v1alpha1/resource.go
+++ b/apis/core/v1alpha1/resource.go
@@ -37,6 +37,12 @@ const (
 	ResourceCredentialsTokenKey = "token"
 )
 
+const (
+	// ExternalNameAnnotationKey is the key in the annotations of a managed resource for the name of the resource
+	// as it appears on provider's systems.
+	ExternalNameAnnotationKey = "crossplane.io/external-name"
+)
+
 // A ResourceClaimSpec defines the desired state of a resource claim.
 type ResourceClaimSpec struct {
 	// WriteConnectionSecretToReference specifies the name of a Secret, in the

--- a/apis/core/v1alpha1/resource.go
+++ b/apis/core/v1alpha1/resource.go
@@ -37,12 +37,6 @@ const (
 	ResourceCredentialsTokenKey = "token"
 )
 
-const (
-	// ExternalNameAnnotationKey is the key in the annotations of a managed resource for the name of the resource
-	// as it appears on provider's systems.
-	ExternalNameAnnotationKey = "crossplane.io/external-name"
-)
-
 // A ResourceClaimSpec defines the desired state of a resource claim.
 type ResourceClaimSpec struct {
 	// WriteConnectionSecretToReference specifies the name of a Secret, in the

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -137,6 +137,17 @@ func RemoveFinalizer(o metav1.Object, finalizer string) {
 	o.SetFinalizers(f)
 }
 
+// FinalizerExists checks whether given finalizer is already set.
+func FinalizerExists(o metav1.Object, finalizer string) bool {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
 // AddLabels to the supplied object.
 func AddLabels(o metav1.Object, labels map[string]string) {
 	l := o.GetLabels()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -23,6 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 )
 
 /*
@@ -192,4 +194,14 @@ func WasCreated(o metav1.Object) bool {
 	// returns a reference while CreationTimestamp returns a value.
 	t := o.GetCreationTimestamp()
 	return !t.IsZero()
+}
+
+// GetExternalName returns the external name annotation value on the resource.
+func GetExternalName(o metav1.Object) string {
+	return o.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]
+}
+
+// SetExternalName sets the external name annotation of the resource.
+func SetExternalName(o metav1.Object, name string) {
+	AddAnnotations(o, map[string]string{v1alpha1.ExternalNameAnnotationKey: name})
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -23,8 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 )
 
 /*
@@ -33,6 +31,12 @@ import (
 	an ObjectReference using ReferenceTo() than it is to make an ObjectReference
 	satisfy metav1.Object.
 */
+
+const (
+	// ExternalNameAnnotationKey is the key in the annotations map of a resource
+	// for the name of the resource as it appears on provider's systems.
+	ExternalNameAnnotationKey = "crossplane.io/external-name"
+)
 
 // ReferenceTo returns an object reference to the supplied object, presumed to
 // be of the supplied group, version, and kind.
@@ -198,10 +202,10 @@ func WasCreated(o metav1.Object) bool {
 
 // GetExternalName returns the external name annotation value on the resource.
 func GetExternalName(o metav1.Object) string {
-	return o.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]
+	return o.GetAnnotations()[ExternalNameAnnotationKey]
 }
 
 // SetExternalName sets the external name annotation of the resource.
 func SetExternalName(o metav1.Object, name string) {
-	AddAnnotations(o, map[string]string{v1alpha1.ExternalNameAnnotationKey: name})
+	AddAnnotations(o, map[string]string{ExternalNameAnnotationKey: name})
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -19,6 +19,8 @@ package meta
 import (
 	"testing"
 
+	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -750,6 +752,58 @@ func TestWasCreated(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := WasCreated(tc.o)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("WasCreated(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetExternalName(t *testing.T) {
+	testName := "my-external-name"
+
+	cases := map[string]struct {
+		o    metav1.Object
+		want string
+	}{
+		"ExternalNameExists": {
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha1.ExternalNameAnnotationKey: testName}}},
+			want: testName,
+		},
+		"NoExternalName": {
+			o:    &corev1.Pod{},
+			want: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetExternalName(tc.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("WasCreated(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalName(t *testing.T) {
+	testName := "my-external-name"
+
+	cases := map[string]struct {
+		o    metav1.Object
+		name string
+		want metav1.Object
+	}{
+		"SetsTheCorrectKey": {
+			o:    &corev1.Pod{},
+			name: testName,
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha1.ExternalNameAnnotationKey: testName}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SetExternalName(tc.o, tc.name)
+			if diff := cmp.Diff(tc.want, tc.o); diff != "" {
 				t.Errorf("WasCreated(...): -want, +got:\n%s", diff)
 			}
 		})

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -506,6 +506,59 @@ func TestRemoveFinalizer(t *testing.T) {
 	}
 }
 
+func TestFinalizerExists(t *testing.T) {
+	finalizer := "fin"
+	funalizer := "fun"
+
+	type args struct {
+		o         metav1.Object
+		finalizer string
+	}
+
+	cases := map[string]struct {
+		args args
+		want bool
+	}{
+		"NoExistingFinalizers": {
+			args: args{
+				o:         &corev1.Pod{},
+				finalizer: finalizer,
+			},
+			want: false,
+		},
+		"FinalizerExists": {
+			args: args{
+				o: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{finalizer},
+					},
+				},
+				finalizer: finalizer,
+			},
+			want: true,
+		},
+		"AnotherFinalizerExists": {
+			args: args{
+				o: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{funalizer},
+					},
+				},
+				finalizer: finalizer,
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, FinalizerExists(tc.args.o, tc.args.finalizer)); diff != "" {
+				t.Errorf("tc.args.o.GetFinalizers(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAddLabels(t *testing.T) {
 	key, value := "key", "value"
 	existingKey, existingValue := "ekey", "evalue"

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -19,8 +19,6 @@ package meta
 import (
 	"testing"
 
-	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -766,7 +764,7 @@ func TestGetExternalName(t *testing.T) {
 		want string
 	}{
 		"ExternalNameExists": {
-			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha1.ExternalNameAnnotationKey: testName}}},
+			o:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: testName}}},
 			want: testName,
 		},
 		"NoExternalName": {
@@ -796,7 +794,7 @@ func TestSetExternalName(t *testing.T) {
 		"SetsTheCorrectKey": {
 			o:    &corev1.Pod{},
 			name: testName,
-			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha1.ExternalNameAnnotationKey: testName}}},
+			want: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{ExternalNameAnnotationKey: testName}}},
 		},
 	}
 

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -155,9 +155,8 @@ func NewAPIManagedBinder(c client.Client) *APIManagedBinder {
 func (a *APIManagedBinder) Bind(ctx context.Context, cm Claim, mg Managed) error {
 	cm.SetBindingPhase(v1alpha1.BindingPhaseBound)
 	// Propagate back the final name of the external resource to the claim.
-	if mg.GetAnnotations() != nil {
-		meta.AddAnnotations(cm,
-			map[string]string{v1alpha1.ExternalNameAnnotationKey: mg.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]})
+	if meta.GetExternalName(mg) != "" {
+		meta.SetExternalName(cm, meta.GetExternalName(mg))
 	}
 	mg.SetBindingPhase(v1alpha1.BindingPhaseBound)
 	if err := a.client.Update(ctx, mg); err != nil {
@@ -183,9 +182,8 @@ func NewAPIManagedStatusBinder(c client.Client) *APIManagedStatusBinder {
 func (a *APIManagedStatusBinder) Bind(ctx context.Context, cm Claim, mg Managed) error {
 	cm.SetBindingPhase(v1alpha1.BindingPhaseBound)
 	// Propagate back the final name of the external resource to the claim.
-	if mg.GetAnnotations() != nil {
-		meta.AddAnnotations(cm,
-			map[string]string{v1alpha1.ExternalNameAnnotationKey: mg.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]})
+	if meta.GetExternalName(mg) != "" {
+		meta.SetExternalName(cm, meta.GetExternalName(mg))
 	}
 	mg.SetBindingPhase(v1alpha1.BindingPhaseBound)
 	if err := a.client.Status().Update(ctx, mg); err != nil {
@@ -314,9 +312,9 @@ func NewManagedNameAsExternalName(c client.Client) *ManagedNameAsExternalName {
 
 // Initialize the given managed resource.
 func (a *ManagedNameAsExternalName) Initialize(ctx context.Context, mg Managed) error {
-	if mg.GetAnnotations() != nil && mg.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey] == mg.GetName() {
+	if meta.GetExternalName(mg) == mg.GetName() {
 		return nil
 	}
-	meta.AddAnnotations(mg, map[string]string{v1alpha1.ExternalNameAnnotationKey: mg.GetName()})
+	meta.SetExternalName(mg, mg.GetName())
 	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
 }

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -321,7 +321,7 @@ func NewManagedNameAsExternalName(c client.Client) *ManagedNameAsExternalName {
 
 // Initialize the given managed resource.
 func (a *ManagedNameAsExternalName) Initialize(ctx context.Context, mg Managed) error {
-	if meta.GetExternalName(mg) == mg.GetName() {
+	if meta.GetExternalName(mg) != "" {
 		return nil
 	}
 	meta.SetExternalName(mg, mg.GetName())

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -945,14 +945,14 @@ func TestManagedNameAsExternalName(t *testing.T) {
 				ctx: context.Background(),
 				mg: &MockManaged{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: testExternalName},
+					Annotations: map[string]string{meta.ExternalNameAnnotationKey: "some-name"},
 				}},
 			},
 			want: want{
 				err: nil,
 				mg: &MockManaged{ObjectMeta: metav1.ObjectMeta{
 					Name:        testExternalName,
-					Annotations: map[string]string{meta.ExternalNameAnnotationKey: testExternalName},
+					Annotations: map[string]string{meta.ExternalNameAnnotationKey: "some-name"},
 				}},
 			},
 		},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -39,7 +39,8 @@ var (
 	_ ManagedBinder               = &APIManagedBinder{}
 	_ ManagedBinder               = &APIManagedStatusBinder{}
 	_ ClaimFinalizer              = &APIClaimFinalizerRemover{}
-	_ ManagedEstablisher          = &APIManagedFinalizerAdder{}
+	_ ManagedInitializer          = &APIManagedFinalizerAdder{}
+	_ ManagedInitializer          = &ManagedNameAsExternalName{}
 	_ ManagedFinalizer            = &APIManagedFinalizerRemover{}
 )
 
@@ -836,7 +837,7 @@ func TestFinalizeManaged(t *testing.T) {
 	}
 }
 
-func TestEstablishManaged(t *testing.T) {
+func TestAPIManagedFinalizerAdder(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		mg  Managed
@@ -881,18 +882,18 @@ func TestEstablishManaged(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			api := NewAPIManagedFinalizerAdder(tc.client)
-			err := api.Establish(tc.args.ctx, tc.args.mg)
+			err := api.Initialize(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("api.Establish(...): -want error, +got error:\n%s", diff)
+				t.Errorf("api.Initialize(...): -want error, +got error:\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.want.mg, tc.args.mg, test.EquateConditions()); diff != "" {
-				t.Errorf("api.Establish(...) Managed: -want, +got:\n%s", diff)
+				t.Errorf("api.Initialize(...) Managed: -want, +got:\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestInitializeManaged(t *testing.T) {
+func TestManagedNameAsExternalName(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		mg  Managed
@@ -962,10 +963,10 @@ func TestInitializeManaged(t *testing.T) {
 			api := NewManagedNameAsExternalName(tc.client)
 			err := api.Initialize(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("api.Establish(...): -want error, +got error:\n%s", diff)
+				t.Errorf("api.Initialize(...): -want error, +got error:\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.want.mg, tc.args.mg, test.EquateConditions()); diff != "" {
-				t.Errorf("api.Establish(...) Managed: -want, +got:\n%s", diff)
+				t.Errorf("api.Initialize(...) Managed: -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/resource/configurator.go
+++ b/pkg/resource/configurator.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -57,8 +55,8 @@ func NewObjectMetaConfigurator(t runtime.ObjectTyper) *ObjectMetaConfigurator {
 func (c *ObjectMetaConfigurator) Configure(_ context.Context, cm Claim, cs NonPortableClass, mg Managed) error {
 	mg.SetNamespace(cs.GetNamespace())
 	mg.SetGenerateName(fmt.Sprintf("%s-%s-", cm.GetNamespace(), cm.GetName()))
-	if cm.GetAnnotations() != nil && cm.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey] != "" {
-		meta.AddAnnotations(mg, map[string]string{v1alpha1.ExternalNameAnnotationKey: cm.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]})
+	if meta.GetExternalName(cm) != "" {
+		meta.SetExternalName(mg, meta.GetExternalName(cm))
 	}
 	// TODO(negz): Don't set this potentially cross-namespace owner reference.
 	// We probably want to use the resource's reclaim policy, not Kubernetes

--- a/pkg/resource/configurator.go
+++ b/pkg/resource/configurator.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -55,7 +57,9 @@ func NewObjectMetaConfigurator(t runtime.ObjectTyper) *ObjectMetaConfigurator {
 func (c *ObjectMetaConfigurator) Configure(_ context.Context, cm Claim, cs NonPortableClass, mg Managed) error {
 	mg.SetNamespace(cs.GetNamespace())
 	mg.SetGenerateName(fmt.Sprintf("%s-%s-", cm.GetNamespace(), cm.GetName()))
-
+	if cm.GetAnnotations() != nil && cm.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey] != "" {
+		meta.AddAnnotations(mg, map[string]string{v1alpha1.ExternalNameAnnotationKey: cm.GetAnnotations()[v1alpha1.ExternalNameAnnotationKey]})
+	}
 	// TODO(negz): Don't set this potentially cross-namespace owner reference.
 	// We probably want to use the resource's reclaim policy, not Kubernetes
 	// garbage collection, to determine whether to delete a managed resource

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -459,7 +459,7 @@ func TestManagedReconciler(t *testing.T) {
 						}
 					},
 					func(r *ManagedReconciler) {
-						r.managed.ManagedEstablisher = ManagedEstablisherFn(func(_ context.Context, mg Managed) error {
+						r.managed.ManagedInitializer = ManagedInitializerFn(func(_ context.Context, mg Managed) error {
 							mg.SetFinalizers(testFinalizers)
 							return nil
 						})
@@ -508,7 +508,7 @@ func TestManagedReconciler(t *testing.T) {
 						}
 					},
 					func(r *ManagedReconciler) {
-						r.managed.ManagedEstablisher = ManagedEstablisherFn(func(_ context.Context, mg Managed) error {
+						r.managed.ManagedInitializer = ManagedInitializerFn(func(_ context.Context, mg Managed) error {
 							mg.SetFinalizers(testFinalizers)
 							return nil
 						})
@@ -553,7 +553,7 @@ func TestManagedReconciler(t *testing.T) {
 						}
 					},
 					func(r *ManagedReconciler) {
-						r.managed.ManagedEstablisher = ManagedEstablisherFn(func(_ context.Context, _ Managed) error {
+						r.managed.ManagedInitializer = ManagedInitializerFn(func(_ context.Context, _ Managed) error {
 							return errBoom
 						})
 					},

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -72,6 +72,31 @@ func TestManagedReconciler(t *testing.T) {
 			},
 			want: want{err: errors.Wrap(errBoom, errGetManaged)},
 		},
+		"InitializeError": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReconcileError(errBoom))
+							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					s: MockSchemeWith(&MockManaged{}),
+				},
+				mg: ManagedKind(MockGVK(&MockManaged{})),
+				o: []ManagedReconcilerOption{
+					WithManagedInitializers(ManagedInitializerFn(func(_ context.Context, mg Managed) error {
+						return errBoom
+					})),
+				},
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+		},
 		"ExternalConnectError": {
 			args: args{
 				m: &MockManager{
@@ -709,6 +734,11 @@ func TestManagedReconciler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			defaultOptions := []ManagedReconcilerOption{
 				func(r *ManagedReconciler) {
+					r.managed.ManagedInitializer = ManagedInitializerFn(func(_ context.Context, mg Managed) error {
+						return nil
+					})
+				},
+				func(r *ManagedReconciler) {
 					r.external = mrExternal{
 						ExternalConnecter: ExternalConnectorFn(func(_ context.Context, _ Managed) (ExternalClient, error) {
 							return tc.args.e, nil
@@ -717,7 +747,6 @@ func TestManagedReconciler(t *testing.T) {
 				},
 			}
 			tc.args.o = append(defaultOptions, tc.args.o...)
-
 			r := NewManagedReconciler(tc.args.m, tc.args.mg, tc.args.o...)
 			got, err := r.Reconcile(reconcile.Request{})
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

This PR introduces `Initializer` hook to generic managed reconciler. Existing `Establisher`s are refactored to be `Initalizer`s. 

`Initialize` is called before any `ExternalClient` calls to make sure everything is ready for queries.

The first use is calculating the external name for the managed resource. The default initializer that all managed reconciler will use is now `ManagedNameAsExternalName`, which means, if not already given, `crossplane.io/external-name` annotation will be populated by the name of the managed resource.

Additionally;
- During `Bind` operation, we propagate back the external name to the claim's annotation.
- During managed resource creation we propagate down the external name annotation from claim to the managed resource.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes https://github.com/crossplaneio/crossplane/issues/624

Implements https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#external-resource-name
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml