### PR TITLE
Add port key to connection secret key constants

### DIFF
--- a/apis/core/v1alpha1/resource.go
+++ b/apis/core/v1alpha1/resource.go
@@ -23,6 +23,8 @@ import (
 const (
 	// ResourceCredentialsSecretEndpointKey is the key inside a connection secret for the connection endpoint
 	ResourceCredentialsSecretEndpointKey = "endpoint"
+	// ResourceCredentialsSecretPortKey is the key inside a connection secret for the connection port
+	ResourceCredentialsSecretPortKey = "port"
 	// ResourceCredentialsSecretUserKey is the key inside a connection secret for the connection user
 	ResourceCredentialsSecretUserKey = "username"
 	// ResourceCredentialsSecretPasswordKey is the key inside a connection secret for the connection password


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

We get port information alongside endpoint from the providers but currently assume that the user can figure out the port I guess. This defines a connection secret key that we can use to represent that information.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml