### PR TITLE
Fix static provisioning edge cases

### DIFF
--- a/pkg/resource/claim_binding_reconciler_test.go
+++ b/pkg/resource/claim_binding_reconciler_test.go
@@ -341,7 +341,7 @@ func TestClaimReconciler(t *testing.T) {
 				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
-			want: want{result: reconcile.Result{Requeue: false}},
+			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
 		"GetResourceClassError": {
 			args: args{
@@ -475,6 +475,7 @@ func TestClaimReconciler(t *testing.T) {
 								// because the zero value of BindingPhase is
 								// BindingPhaseUnset.
 								mg := &MockManaged{}
+								mg.SetClaimReference(&corev1.ObjectReference{})
 								mg.SetCreationTimestamp(now)
 								*o = *mg
 								return nil
@@ -514,6 +515,7 @@ func TestClaimReconciler(t *testing.T) {
 							case *MockManaged:
 								mg := &MockManaged{}
 								mg.SetCreationTimestamp(now)
+								mg.SetClaimReference(&corev1.ObjectReference{})
 								mg.SetBindingPhase(v1alpha1.BindingPhaseUnbindable)
 								*o = *mg
 								return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #28

Quoting the above issue:

> There are three scenarios we need to make sure the claim reconciler handles:
>
> 1. Dynamic provisioning. No managed resource exists. A resource claim is created with a portable class reference and without a managed resource reference. In this case the claim reconciler should dynamically provision and then bind to a managed resource.
> 1. Resource-first static provisioning. A managed resource is created explicitly, without using a resource class. Later (or simultaneously), a resource claim that references (via its resource reference) that managed resource is created. We should skip dynamic provisioning and go straight to binding.
> 1. Claim-first static provisioning. A resource claim is created that references (via its resource reference) a managed resource that does not yet exist. We should fail to reconcile that resource claim until such time as the referenced managed resource is created (out of band) and becomes bindable, at which point we should bind to it.

While investigating I found that scenario 3 lead to a nil pointer exception, and scenario 2 was partially broken; static provisioning would only work when the statically provisioned managed resource was available for binding at the time the claim was submitted. If the resource was still being created when the claim was submitted it would never bind. I also realised we were susceptible to a nil pointer in a pathological case in which a managed resource referenced a claim that had neither a resource reference or a class reference. I believe this PR fixes all of these issues.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml