### PR TITLE
Make 'Observe' method conditional on having all the references resolved

### DIFF
--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -29,13 +29,6 @@ type MockBindable struct{ Phase v1alpha1.BindingPhase }
 func (m *MockBindable) SetBindingPhase(p v1alpha1.BindingPhase) { m.Phase = p }
 func (m *MockBindable) GetBindingPhase() v1alpha1.BindingPhase  { return m.Phase }
 
-type MockConditioned struct{ Conditions []v1alpha1.Condition }
-
-func (m *MockConditioned) SetConditions(c ...v1alpha1.Condition) { m.Conditions = c }
-func (m *MockConditioned) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Condition {
-	return v1alpha1.Condition{Type: ct, Status: corev1.ConditionUnknown}
-}
-
 type MockClaimReferencer struct{ Ref *corev1.ObjectReference }
 
 func (m *MockClaimReferencer) SetClaimReference(r *corev1.ObjectReference) { m.Ref = r }
@@ -99,7 +92,7 @@ type MockClaim struct {
 	MockClassReferencer
 	MockManagedResourceReferencer
 	MockLocalConnectionSecretWriterTo
-	MockConditioned
+	v1alpha1.ConditionedStatus
 	MockBindable
 }
 
@@ -122,6 +115,6 @@ type MockManaged struct {
 	MockClaimReferencer
 	MockConnectionSecretWriterTo
 	MockReclaimer
-	MockConditioned
+	v1alpha1.ConditionedStatus
 	MockBindable
 }


### PR DESCRIPTION
Signed-off-by: soorena776 <javad@upbound.io>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Fixes #62 
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml