### PR TITLE
Managed resource reconciler refactoring

### DIFF
--- a/apis/core/v1alpha1/condition.go
+++ b/apis/core/v1alpha1/condition.go
@@ -59,7 +59,7 @@ const (
 // Reason references for a resource are or are not resolved
 const (
 	ReasonReferenceResolveSuccess  ConditionReason = "Successfully resolved managed resource references to other resources"
-	ReasonResolveReferencesBlocked ConditionReason = "One or more of referenced resources do not exist, or are not yet Ready"
+	ReasonResolveReferencesBlocked ConditionReason = "One or more referenced resources do not exist, or are not yet Ready"
 )
 
 // A Condition that may apply to a managed resource.

--- a/apis/core/v1alpha1/condition.go
+++ b/apis/core/v1alpha1/condition.go
@@ -262,7 +262,7 @@ func ReconcileError(err error) Condition {
 }
 
 // ReferenceResolutionSuccess returns a condition indicating that Crossplane
-// successfully resolved the references used in the managed resource
+// successfully resolved the references used in the managed resource.
 func ReferenceResolutionSuccess() Condition {
 	return Condition{
 		Type:               TypeReferencesResolved,
@@ -275,7 +275,7 @@ func ReferenceResolutionSuccess() Condition {
 // ReferenceResolutionBlocked returns a condition indicating that Crossplane is
 // unable to resolve the references used in the managed resource. This could
 // mean that one or more of referred resources do not yet exist, or are not yet
-// Ready
+// Ready.
 func ReferenceResolutionBlocked(err error) Condition {
 	return Condition{
 		Type:               TypeReferencesResolved,

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -316,9 +316,9 @@ func (a *APIManagedFinalizerAdder) Initialize(ctx context.Context, mg Managed) e
 	return errors.Wrap(a.client.Update(ctx, mg), errUpdateManaged)
 }
 
-// ManagedNameAsExternalName writes the name of the managed resource to
-// the external name annotation field in order to be used as name of
-// the external resource in provider.
+// ManagedNameAsExternalName writes the name of the managed resource to the
+// external name annotation field in order to be used as name of the external
+// resource in provider.
 type ManagedNameAsExternalName struct{ client client.Client }
 
 // NewManagedNameAsExternalName returns a new ManagedNameAsExternalName.
@@ -326,8 +326,8 @@ func NewManagedNameAsExternalName(c client.Client) *ManagedNameAsExternalName {
 	return &ManagedNameAsExternalName{client: c}
 }
 
-// Initialize the given managed resource.
-func (a *ManagedNameAsExternalName) Initialize(ctx context.Context, mg Managed) error {
+// Annotate the supplied managed resource.
+func (a *ManagedNameAsExternalName) Annotate(ctx context.Context, mg Managed) error {
 	if meta.GetExternalName(mg) != "" {
 		return nil
 	}

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -489,10 +489,10 @@ func TestBind(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateManaged),
-				cm:  &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+				cm:  &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -518,13 +518,13 @@ func TestBind(t *testing.T) {
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateClaim),
 				cm: &MockClaim{
-					ObjectMeta:   metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &MockManaged{
 					ObjectMeta:          metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -538,10 +538,10 @@ func TestBind(t *testing.T) {
 			},
 			want: want{
 				err: nil,
-				cm:  &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+				cm:  &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -558,12 +558,12 @@ func TestBind(t *testing.T) {
 			want: want{
 				err: nil,
 				cm: &MockClaim{
-					ObjectMeta:   metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					ObjectMeta:          metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -625,7 +625,7 @@ func TestStatusBind(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateManaged),
-				cm:  &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+				cm:  &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
 				},
@@ -644,10 +644,10 @@ func TestStatusBind(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateManagedStatus),
-				cm:  &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+				cm:  &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -676,13 +676,13 @@ func TestStatusBind(t *testing.T) {
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateClaim),
 				cm: &MockClaim{
-					ObjectMeta:   metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &MockManaged{
 					ObjectMeta:          metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -699,10 +699,10 @@ func TestStatusBind(t *testing.T) {
 			},
 			want: want{
 				err: nil,
-				cm:  &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+				cm:  &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &MockManaged{
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -722,13 +722,13 @@ func TestStatusBind(t *testing.T) {
 			want: want{
 				err: nil,
 				cm: &MockClaim{
-					ObjectMeta:   metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					ObjectMeta:    metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
+					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 				mg: &MockManaged{
 					ObjectMeta:          metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
 					MockClaimReferencer: MockClaimReferencer{meta.ReferenceTo(&MockClaim{}, MockGVK(&MockClaim{}))},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
 		},
@@ -777,7 +777,7 @@ func TestFinalizeResource(t *testing.T) {
 				ctx: context.Background(),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
 				},
 			},
@@ -785,7 +785,7 @@ func TestFinalizeResource(t *testing.T) {
 				err: nil,
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -798,7 +798,7 @@ func TestFinalizeResource(t *testing.T) {
 				ctx: context.Background(),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
 				},
 			},
@@ -806,7 +806,7 @@ func TestFinalizeResource(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -852,14 +852,14 @@ func TestStatusFinalizeResource(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				mg: &MockManaged{
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
 				},
 			},
 			want: want{
 				err: nil,
 				mg: &MockManaged{
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -871,14 +871,14 @@ func TestStatusFinalizeResource(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				mg: &MockManaged{
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
 				},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				mg: &MockManaged{
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -892,7 +892,7 @@ func TestStatusFinalizeResource(t *testing.T) {
 				ctx: context.Background(),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseBound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
 				},
 			},
@@ -900,7 +900,7 @@ func TestStatusFinalizeResource(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManagedStatus),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					MockBindable:        MockBindable{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -40,8 +40,8 @@ var (
 	_ ManagedBinder               = &APIManagedStatusBinder{}
 	_ ClaimFinalizer              = &APIClaimFinalizerRemover{}
 	_ ManagedInitializer          = &APIManagedFinalizerAdder{}
-	_ ManagedInitializer          = &ManagedNameAsExternalName{}
 	_ ManagedFinalizer            = &APIManagedFinalizerRemover{}
+	_ ManagedAnnotator            = &ManagedNameAsExternalName{}
 )
 
 func TestCreate(t *testing.T) {
@@ -1157,7 +1157,7 @@ func TestManagedNameAsExternalName(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			api := NewManagedNameAsExternalName(tc.client)
-			err := api.Initialize(tc.args.ctx, tc.args.mg)
+			err := api.Annotate(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("api.Initialize(...): -want error, +got error:\n%s", diff)
 			}

--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package resource
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 )
@@ -92,8 +95,6 @@ func (m *MockReclaimer) GetReclaimPolicy() v1alpha1.ReclaimPolicy  { return m.Po
 var _ Claim = &MockClaim{}
 
 type MockClaim struct {
-	runtime.Object
-
 	metav1.ObjectMeta
 	MockClassSelector
 	MockClassReferencer
@@ -103,20 +104,44 @@ type MockClaim struct {
 	MockBindable
 }
 
+func (m *MockClaim) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (m *MockClaim) DeepCopyObject() runtime.Object {
+	out := &MockClaim{}
+	j, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	json.Unmarshal(j, out)
+	return out
+}
+
 var _ Class = &MockClass{}
 
 type MockClass struct {
-	runtime.Object
-
 	metav1.ObjectMeta
 	MockReclaimer
+}
+
+func (m *MockClass) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (m *MockClass) DeepCopyObject() runtime.Object {
+	out := &MockClass{}
+	j, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	json.Unmarshal(j, out)
+	return out
 }
 
 var _ Managed = &MockManaged{}
 
 type MockManaged struct {
-	runtime.Object
-
 	metav1.ObjectMeta
 	MockClassReferencer
 	MockClaimReferencer
@@ -124,4 +149,18 @@ type MockManaged struct {
 	MockReclaimer
 	MockConditioned
 	MockBindable
+}
+
+func (m *MockManaged) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (m *MockManaged) DeepCopyObject() runtime.Object {
+	out := &MockManaged{}
+	j, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	json.Unmarshal(j, out)
+	return out
 }

--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -27,18 +27,6 @@ import (
 	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 )
 
-type MockBindable struct{ Phase v1alpha1.BindingPhase }
-
-func (m *MockBindable) SetBindingPhase(p v1alpha1.BindingPhase) { m.Phase = p }
-func (m *MockBindable) GetBindingPhase() v1alpha1.BindingPhase  { return m.Phase }
-
-type MockConditioned struct{ Conditions []v1alpha1.Condition }
-
-func (m *MockConditioned) SetConditions(c ...v1alpha1.Condition) { m.Conditions = c }
-func (m *MockConditioned) GetCondition(ct v1alpha1.ConditionType) v1alpha1.Condition {
-	return v1alpha1.Condition{Type: ct, Status: corev1.ConditionUnknown}
-}
-
 type MockClaimReferencer struct{ Ref *corev1.ObjectReference }
 
 func (m *MockClaimReferencer) SetClaimReference(r *corev1.ObjectReference) { m.Ref = r }
@@ -100,8 +88,8 @@ type MockClaim struct {
 	MockClassReferencer
 	MockManagedResourceReferencer
 	MockLocalConnectionSecretWriterTo
-	MockConditioned
-	MockBindable
+	v1alpha1.ConditionedStatus
+	v1alpha1.BindingStatus
 }
 
 func (m *MockClaim) GetObjectKind() schema.ObjectKind {
@@ -147,8 +135,8 @@ type MockManaged struct {
 	MockClaimReferencer
 	MockConnectionSecretWriterTo
 	MockReclaimer
-	MockConditioned
-	MockBindable
+	v1alpha1.ConditionedStatus
+	v1alpha1.BindingStatus
 }
 
 func (m *MockManaged) GetObjectKind() schema.ObjectKind {

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -32,9 +32,8 @@ import (
 )
 
 const (
-	managedControllerName               = "managedresource.crossplane.io"
-	managedFinalizerName                = "finalizer." + managedControllerName
-	managedResourceStructTagPackageName = "resource"
+	managedControllerName = "managedresource.crossplane.io"
+	managedFinalizerName  = "finalizer." + managedControllerName
 
 	managedReconcileTimeout = 1 * time.Minute
 

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -402,21 +402,6 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
 
-	if !IsConditionTrue(managed.GetCondition(v1alpha1.TypeReferencesResolved)) {
-		if err := r.managed.ResolveReferences(ctx, managed); err != nil {
-			condition := v1alpha1.ReconcileError(err)
-			if IsReferencesAccessError(err) {
-				condition = v1alpha1.ReferenceResolutionBlocked(err)
-			}
-
-			managed.SetConditions(condition)
-			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
-		}
-
-		// Add ReferenceResolutionSuccess to the conditions
-		managed.SetConditions(v1alpha1.ReferenceResolutionSuccess())
-	}
-
 	observation, err := external.Observe(ctx, managed)
 	if err != nil {
 		// We'll usually hit this case if our Provider credentials are invalid
@@ -483,6 +468,21 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 		managed.SetConditions(v1alpha1.ReconcileError(err))
 		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 	}
+
+	if err := r.managed.ResolveReferences(ctx, managed); err != nil {
+		condition := v1alpha1.ReconcileError(err)
+		if IsReferencesAccessError(err) {
+			condition = v1alpha1.ReferenceResolutionBlocked(err)
+		}
+
+		// If any of our referenced resources are not yet ready (or if we
+		// encountered an error resolving them) we want to try again after a
+		// short wait. If this is the first time we encounter this situation
+		// we'll be requeued implicitly due to the status update.
+		managed.SetConditions(condition)
+		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+	}
+	managed.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 
 	if !observation.ResourceExists {
 		creation, err := external.Create(ctx, managed)

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -443,8 +443,14 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 				return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 			}
 
+			// We've successfully requested deletion of our external resource.
+			// We queue another reconcile after a short wait rather than
+			// immediately finalizing our delete in order to verify that the
+			// external resource was actually deleted. If it no longer exists
+			// we'll skip this block on the next reconcile and proceed to
+			// unpublish and finalize. If it still exists we'll re-enter this
+			// block and try again.
 			managed.SetConditions(v1alpha1.ReconcileSuccess())
-			// TODO(negz): Why do we requeue here rather than just proceeding?
 			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 		if err := r.managed.UnpublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {
@@ -463,11 +469,11 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 		}
 
 		// We've successfully finalized the deletion of our external and managed
-		// resources.
+		// resources. We'll be requeued implicitly (if we still exist) due to
+		// the finalizer deletion and subsequent status update, but otherwise
+		// there's no more work to do.
 		managed.SetConditions(v1alpha1.ReconcileSuccess())
-		// TODO(negz): Why do we requeue here? We've deleted our resource and
-		// removed its finalizer at this stage. There's nothing more to do.
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: false}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
 	}
 
 	if err := r.managed.PublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -410,9 +410,7 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 			}
 
 			managed.SetConditions(condition)
-			// TODO(negz): The declaration of our dependencies implies we expect
-			// they are or will soon be ready. This should be a short wait.
-			return reconcile.Result{RequeueAfter: r.longWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 
 		// Add ReferenceResolutionSuccess to the conditions

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -184,7 +184,6 @@ func TestManagedReconciler(t *testing.T) {
 							want := &MockManaged{}
 							want.SetDeletionTimestamp(&now)
 							want.SetReclaimPolicy(v1alpha1.ReclaimDelete)
-							want.SetConditions(v1alpha1.Deleting())
 							want.SetConditions(v1alpha1.ReconcileError(errBoom))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "An error deleting an external resource should be reported as a conditioned status."
@@ -229,7 +228,6 @@ func TestManagedReconciler(t *testing.T) {
 							want := &MockManaged{}
 							want.SetDeletionTimestamp(&now)
 							want.SetReclaimPolicy(v1alpha1.ReclaimDelete)
-							want.SetConditions(v1alpha1.Deleting())
 							want.SetConditions(v1alpha1.ReconcileSuccess())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A deleted external resource should be reported as a conditioned status."
@@ -479,6 +477,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileError(errBoom))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors while creating an external resource should be reported as a conditioned status."
@@ -517,6 +516,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileError(errBoom))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after creation should be reported as a conditioned status."
@@ -566,6 +566,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileSuccess())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Successful managed resource creation should be reported as a conditioned status."
@@ -594,6 +595,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileSuccess())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful no-op reconcile should be reported as a conditioned status."
@@ -629,6 +631,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileError(errBoom))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors while updating an external resource should be reported as a conditioned status."
@@ -667,6 +670,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileError(errBoom))
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "Errors publishing connection details after an update should be reported as a conditioned status."
@@ -716,6 +720,7 @@ func TestManagedReconciler(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 							want := &MockManaged{}
+							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
 							want.SetConditions(v1alpha1.ReconcileSuccess())
 							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
 								reason := "A successful managed resource update should be reported as a conditioned status."

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -137,7 +137,7 @@ func TestManagedReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"ResolveReferencesNotReadyError": {
-			reason: "Dependencies on unready references should trigger a requeue after a long wait.",
+			reason: "Dependencies on unready references should trigger a requeue after a short wait.",
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{
@@ -163,10 +163,10 @@ func TestManagedReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedLongWait}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"ResolveReferencesError": {
-			reason: "Errors during reference resolution references should trigger a requeue after a long wait.",
+			reason: "Errors during reference resolution references should trigger a requeue after a short wait.",
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{
@@ -192,7 +192,7 @@ func TestManagedReconciler(t *testing.T) {
 					})),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedLongWait}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"ExternalObserveError": {
 			reason: "Errors observing the external resource should trigger a requeue after a short wait.",

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -401,7 +401,7 @@ func TestManagedReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"DeleteSuccessful": {
-			reason: "Successful managed resource deletion should trigger a requeue after a short wait.",
+			reason: "Successful managed resource deletion should not trigger a requeue.",
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{
@@ -439,7 +439,7 @@ func TestManagedReconciler(t *testing.T) {
 					WithManagedFinalizers(),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: false}},
 		},
 		"PublishObservationConnectionDetailsError": {
 			reason: "Errors publishing connection details after observation should trigger a requeue after a short wait.",

--- a/pkg/resource/reference_resolver.go
+++ b/pkg/resource/reference_resolver.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,11 +94,10 @@ func IsReferencesAccessError(err error) bool {
 	return result
 }
 
-// CanReference is a type that is used as ReferenceResolver input
-type CanReference interface {
-	runtime.Object
-	metav1.Object
-}
+// A CanReference is a resource that can reference another resource in its
+// spec in order to automatically resolve corresponding spec field values
+// by inspecting the referenced resource.
+type CanReference runtime.Object
 
 // An AttributeReferencer resolves cross-resource attribute references. See
 // https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-cross-resource-referencing.md

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -376,15 +376,15 @@ func TestSetBindable(t *testing.T) {
 		want v1alpha1.BindingPhase
 	}{
 		"BindableIsUnbindable": {
-			b:    &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseUnbindable}},
+			b:    &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbindable}},
 			want: v1alpha1.BindingPhaseUnbound,
 		},
 		"BindableIsUnbound": {
-			b:    &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseUnbound}},
+			b:    &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound}},
 			want: v1alpha1.BindingPhaseUnbound,
 		},
 		"BindableIsBound": {
-			b:    &MockClaim{MockBindable: MockBindable{Phase: v1alpha1.BindingPhaseBound}},
+			b:    &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 			want: v1alpha1.BindingPhaseBound,
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Opening this as a draft for now, because it's fairly wide ranging and should probably be more than one PR. In the meantime everything is broken down by commit fairly cleanly.

The PR:

* Adds finalizers right before the creation block - see rationale in that commit message.
* Triggers reference resolution on every reconcile - this will require updates to referencers to ensure they're idempotent (i.e. only append the resolved value to a slice once).
* Avoids updating the managed resource if it doesn't change during the reference resolution process.
* Removes the check for the `attributereferencer` struct tag - see rationale in that commit message.
* Cleans up the managed reconciler and reference resolver tests.

Fixes #63
Fixes #62 
Fixes #53 
Fixes #51 

I've tested this all out by creating a GKE cluster and CloudSQL database using the `examples/workload` manifests.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml