### PR TITLE
Don't trigger a requeue after a successful deletion 

### DIFF
--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -446,8 +446,14 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 				return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 			}
 
+			// We've successfully requested deletion of our external resource.
+			// We queue another reconcile after a short wait rather than
+			// immediately finalizing our delete in order to verify that the
+			// external resource was actually deleted. If it no longer exists
+			// we'll skip this block on the next reconcile and proceed to
+			// unpublish and finalize. If it still exists we'll re-enter this
+			// block and try again.
 			managed.SetConditions(v1alpha1.ReconcileSuccess())
-			// TODO(negz): Why do we requeue here rather than just proceeding?
 			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 		}
 		if err := r.managed.UnpublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {
@@ -466,11 +472,11 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 		}
 
 		// We've successfully finalized the deletion of our external and managed
-		// resources.
+		// resources. We'll be requeued implicitly (if we still exist) due to
+		// the finalizer deletion and subsequent status update, but otherwise
+		// there's no more work to do.
 		managed.SetConditions(v1alpha1.ReconcileSuccess())
-		// TODO(negz): Why do we requeue here? We've deleted our resource and
-		// removed its finalizer at this stage. There's nothing more to do.
-		return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
+		return reconcile.Result{Requeue: false}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
 	}
 
 	if err := r.managed.PublishConnection(ctx, managed, observation.ConnectionDetails); err != nil {

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -404,24 +404,13 @@ func TestManagedReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"DeleteSuccessful": {
-			reason: "Successful managed resource deletion should not trigger a requeue.",
+			reason: "Successful managed resource deletion should not trigger a requeue or status update.",
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{
 						MockGet: test.NewMockGetFn(nil, func(obj runtime.Object) error {
 							mg := obj.(*MockManaged)
 							mg.SetDeletionTimestamp(&now)
-							return nil
-						}),
-						MockStatusUpdate: test.MockStatusUpdateFn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
-							want := &MockManaged{}
-							want.SetDeletionTimestamp(&now)
-							want.SetConditions(v1alpha1.ReferenceResolutionSuccess())
-							want.SetConditions(v1alpha1.ReconcileSuccess())
-							if diff := cmp.Diff(want, obj, test.EquateConditions()); diff != "" {
-								reason := "Successful resource deletion should be reported as a conditioned status."
-								t.Errorf("\nReason: %s\n-want, +got:\n%s", reason, diff)
-							}
 							return nil
 						}),
 					},

--- a/pkg/resource/managed_reconciler_test.go
+++ b/pkg/resource/managed_reconciler_test.go
@@ -404,7 +404,7 @@ func TestManagedReconciler(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
 		},
 		"DeleteSuccessful": {
-			reason: "Successful managed resource deletion should trigger a requeue after a short wait.",
+			reason: "Successful managed resource deletion should not trigger a requeue.",
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{
@@ -443,7 +443,7 @@ func TestManagedReconciler(t *testing.T) {
 					WithManagedFinalizers(),
 				},
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultManagedShortWait}},
+			want: want{result: reconcile.Result{Requeue: false}},
 		},
 		"PublishObservationConnectionDetailsError": {
 			reason: "Errors publishing connection details after observation should trigger a requeue after a short wait.",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

I can't see any reason we'd need to requeue after removing our finalizer.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml