### PR TITLE
Add managed resource finalizer immediately before creating

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -233,13 +233,13 @@ func (a *APIStatusBinder) Unbind(ctx context.Context, _ Claim, mg Managed) error
 	// TODO(negz): We probably want to delete the managed resource here if its
 	// reclaim policy is delete, rather than relying on garbage collection, per
 	// https://github.com/crossplaneio/crossplane/issues/550
-	mg.SetBindingPhase(v1alpha1.BindingPhaseUnbound)
-	mg.SetClaimReference(nil)
 
+	mg.SetClaimReference(nil)
 	if err := a.client.Update(ctx, mg); err != nil {
 		return errors.Wrap(IgnoreNotFound(err), errUpdateManaged)
 	}
 
+	mg.SetBindingPhase(v1alpha1.BindingPhaseUnbound)
 	return errors.Wrap(IgnoreNotFound(a.client.Status().Update(ctx, mg)), errUpdateManagedStatus)
 }
 

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -826,7 +826,7 @@ func TestUnbind(t *testing.T) {
 		})
 	}
 }
-func TestStatusFinalizeResource(t *testing.T) {
+func TestStatusUnbind(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		cm  Claim
@@ -880,7 +880,7 @@ func TestStatusFinalizeResource(t *testing.T) {
 			want: want{
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				mg: &MockManaged{
-					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -50,11 +50,16 @@ const (
 // resource, for example usernames, passwords, endpoints, ports, etc.
 type ConnectionDetails map[string][]byte
 
-// A ManagedConnectionPublisher manages the supplied ConnectionDetails for the supplied
-// Managed resource. ManagedPublishers must handle the case in which the
-// supplied ConnectionDetails are empty.
+// A ManagedConnectionPublisher manages the supplied ConnectionDetails for the
+// supplied Managed resource. ManagedPublishers must handle the case in which
+// the supplied ConnectionDetails are empty.
 type ManagedConnectionPublisher interface {
+	// PublishConnection details for the supplied Managed resource. Publishing
+	// must be additive; i.e. if details (a, b, c) are published, subsequently
+	// publicing details (b, c, d) should update (b, c) but not remove a.
 	PublishConnection(ctx context.Context, mg Managed, c ConnectionDetails) error
+
+	// UnpublishConnection details for the supplied Managed resource.
 	UnpublishConnection(ctx context.Context, mg Managed, c ConnectionDetails) error
 }
 
@@ -64,18 +69,19 @@ type ManagedConnectionPublisherFns struct {
 	UnpublishConnectionFn func(ctx context.Context, mg Managed, c ConnectionDetails) error
 }
 
-// PublishConnection calls plugged PublishConnectionFn.
+// PublishConnection details for the supplied Managed resource.
 func (fn ManagedConnectionPublisherFns) PublishConnection(ctx context.Context, mg Managed, c ConnectionDetails) error {
 	return fn.PublishConnectionFn(ctx, mg, c)
 }
 
-// UnpublishConnection calls plugged UnpublishConnectionFn.
+// UnpublishConnection details for the supplied Managed resource.
 func (fn ManagedConnectionPublisherFns) UnpublishConnection(ctx context.Context, mg Managed, c ConnectionDetails) error {
 	return fn.UnpublishConnectionFn(ctx, mg, c)
 }
 
 // A ManagedInitializer establishes ownership of the supplied Managed resource.
-// This typically involves the operations that are run before calling any ExternalClient methods.
+// This typically involves the operations that are run before calling any
+// ExternalClient methods.
 type ManagedInitializer interface {
 	Initialize(ctx context.Context, mg Managed) error
 }
@@ -94,7 +100,8 @@ func (cc InitializerChain) Initialize(ctx context.Context, mg Managed) error {
 	return nil
 }
 
-// ManagedInitializerFn is the pluggable struct to produce objects with ManagedInitializer interface.
+// A ManagedInitializerFn is a function that satisfies the ManagedInitializer
+// interface.
 type ManagedInitializerFn func(ctx context.Context, mg Managed) error
 
 // Initialize calls ManagedInitializerFn function.
@@ -102,7 +109,18 @@ func (m ManagedInitializerFn) Initialize(ctx context.Context, mg Managed) error 
 	return m(ctx, mg)
 }
 
-// ManagedReferenceResolverFn is the pluggable struct to produce objects with ManagedReferenceResolver interface.
+// A ManagedReferenceResolver resolves references to other managed resources.
+type ManagedReferenceResolver interface {
+	// ResolveReferences finds all fields in the supplied CanReference that are
+	// references to Kubernetes resources, then uses the fields of those
+	// resources to update corresponding fields in CanReference, for example
+	// setting .spec.network to the name of the Network resource specified as
+	// .spec.networkRef.
+	ResolveReferences(ctx context.Context, res CanReference) error
+}
+
+// a ManagedReferenceResolverFn is a function that satisfies the
+// ManagedReferenceResolver interface.
 type ManagedReferenceResolverFn func(context.Context, CanReference) error
 
 // ResolveReferences calls ManagedReferenceResolverFn function
@@ -113,13 +131,17 @@ func (m ManagedReferenceResolverFn) ResolveReferences(ctx context.Context, res C
 // An ExternalConnecter produces a new ExternalClient given the supplied
 // Managed resource.
 type ExternalConnecter interface {
+	// Connect to the provider specified by the supplied managed resource and
+	// produce an ExternalClient.
 	Connect(ctx context.Context, mg Managed) (ExternalClient, error)
 }
 
-// ExternalConnectorFn is the pluggable struct to produce an ExternalConnector from given functions.
+// An ExternalConnectorFn is a function that satisfies the ExternalConnecter
+// interface.
 type ExternalConnectorFn func(ctx context.Context, mg Managed) (ExternalClient, error)
 
-// Connect calls plugged ExternalConnectorFn function.
+// Connect to the provider specified by the supplied managed resource and
+// produce an ExternalClient.
 func (ec ExternalConnectorFn) Connect(ctx context.Context, mg Managed) (ExternalClient, error) {
 	return ec(ctx, mg)
 }
@@ -151,8 +173,8 @@ type ExternalClient interface {
 	Delete(ctx context.Context, mg Managed) error
 }
 
-// ExternalClientFns is a pluggable struct to produce an ExternalClient from the
-// given functions.
+// ExternalClientFns are a series of functions that satisfy the ExternalClient
+// interface.
 type ExternalClientFns struct {
 	ObserveFn func(ctx context.Context, mg Managed) (ExternalObservation, error)
 	CreateFn  func(ctx context.Context, mg Managed) (ExternalCreation, error)
@@ -160,23 +182,29 @@ type ExternalClientFns struct {
 	DeleteFn  func(ctx context.Context, mg Managed) error
 }
 
-// Observe calls plugged ObserveFn function.
+// Observe the external resource the supplied Managed resource represents, if
+// any.
 func (e ExternalClientFns) Observe(ctx context.Context, mg Managed) (ExternalObservation, error) {
 	return e.ObserveFn(ctx, mg)
 }
 
-// Create calls plugged CreateFn function.
+// Create an external resource per the specifications of the supplied Managed
+// resource.
 func (e ExternalClientFns) Create(ctx context.Context, mg Managed) (ExternalCreation, error) {
 	return e.CreateFn(ctx, mg)
 }
 
-// Update calls plugged UpdateFn function.
+// Update the external resource represented by the supplied Managed resource, if
+// necessary.
 func (e ExternalClientFns) Update(ctx context.Context, mg Managed) (ExternalUpdate, error) {
 	return e.UpdateFn(ctx, mg)
 }
 
-// Delete calls plugged DeleteFn function.
-func (e ExternalClientFns) Delete(ctx context.Context, mg Managed) error { return e.DeleteFn(ctx, mg) }
+// Delete the external resource upon deletion of its associated Managed
+// resource.
+func (e ExternalClientFns) Delete(ctx context.Context, mg Managed) error {
+	return e.DeleteFn(ctx, mg)
+}
 
 // A NopConnecter does nothing.
 type NopConnecter struct{}

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -521,7 +521,7 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 			return reconcile.Result{RequeueAfter: r.shortWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, managed)), errUpdateManagedStatus)
 		}
 
-		// We've successfully deleted external resource (if necessary) and
+		// We've successfully deleted our external resource (if necessary) and
 		// removed our finalizer. If we assume we were the only controller that
 		// added a finalizer to this resource then it should no longer exist and
 		// thus there is no point trying to update its status.

--- a/pkg/resource/reference_resolver.go
+++ b/pkg/resource/reference_resolver.go
@@ -118,15 +118,6 @@ type AttributeReferencer interface {
 	Assign(res CanReference, value string) error
 }
 
-// A ManagedReferenceResolver resolves the references to other managed
-// resources, by looking them up in the Kubernetes API server. The references
-// are the fields in the managed resource that implement AttributeReferencer
-// interface and have
-// `attributeReferencerTagName:"managedResourceStructTagPackageName"` tag
-type ManagedReferenceResolver interface {
-	ResolveReferences(context.Context, CanReference) error
-}
-
 // An AttributeReferencerFinder returns all types within the supplied object
 // that satisfy AttributeReferencer.
 type AttributeReferencerFinder interface {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #63
Fixes #62
Fixes #51
Fixes #25 

This commit moves where we set the finalizer for managed resources to right before creating them, not at the beginning of the reconcile. This means we'll be less likely to encounter issues where we can't delete a managed resource because we could never create it in the first place, but we added a finalizer.

* By the time we get here we know our Observe call worked. If (for example) our cloud provider credentials were completely wrong, we'd never proceed far enough to add the finalizer.
* If Observe works but Create fails (for example because we had RO cloud provider credentials) we would already have added the finalizer, but...
* When the managed resource was deleted we'd be able to Observe that the external resource does not exist (because we were never able to Create it) and thus would not call Delete on the external resource and go straight to unpublishing credentials and removing the finalizer.

This commit also renames and refactors a bunch of our interfaces to use less obtuse names. Previously sometimes a "finalize" method unbound a managed resource, while at other times it removed the finalizer. Similarly, finalizers were added in "initialize". We now have a 'Binder' interface with bind and unbind methods, and two 'Finalizer' interfaces (one for Claim, and one for Managed) that add and remove finalizers, as you would expect.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml