### PR TITLE
Requeue when no resource claims match labels or default annotations

### DIFF
--- a/pkg/resource/claim_defaulting_reconciler.go
+++ b/pkg/resource/claim_defaulting_reconciler.go
@@ -130,9 +130,12 @@ func (r *ClaimDefaultingReconciler) Reconcile(req reconcile.Request) (reconcile.
 	}
 
 	if len(defaults) == 0 {
-		// None of our classes are annotated as the default.
-		// There's nothing for us to do.
-		return reconcile.Result{Requeue: false}, nil
+		// None of our classes are annotated as the default. We can't be sure
+		// whether another controller owns the default class, or whether there
+		// is no default class, so we requeue after a short wait. We'll abort
+		// the next reconcile immediately if another controller defaulted the
+		// claim.
+		return reconcile.Result{RequeueAfter: aShortWait}, nil
 	}
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/resource/claim_defaulting_reconciler_test.go
+++ b/pkg/resource/claim_defaulting_reconciler_test.go
@@ -132,7 +132,7 @@ func TestClaimDefaultingReconciler(t *testing.T) {
 				of: ClaimKind(MockGVK(&MockClaim{})),
 				to: ClassKind(MockGVK(&MockClass{})),
 			},
-			want: want{result: reconcile.Result{Requeue: false}},
+			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
 		"UpdateClaimError": {
 			args: args{

--- a/pkg/resource/claim_scheduling_reconciler.go
+++ b/pkg/resource/claim_scheduling_reconciler.go
@@ -133,9 +133,11 @@ func (r *ClaimSchedulingReconciler) Reconcile(req reconcile.Request) (reconcile.
 	}
 
 	if len(classes.Items) == 0 {
-		// None of our classes matched the class selector.
-		// There's nothing for us to do.
-		return reconcile.Result{Requeue: false}, nil
+		// None of our classes matched the selector. We can't be sure whether
+		// another controller owns classes that matched the selector, or whether
+		// no classes match, so we requeue after a short wait. We'll abort the
+		// next reconcile immediately if another controller scheduled the claim.
+		return reconcile.Result{RequeueAfter: aShortWait}, nil
 	}
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/resource/claim_scheduling_reconciler_test.go
+++ b/pkg/resource/claim_scheduling_reconciler_test.go
@@ -131,7 +131,7 @@ func TestClaimSchedulingReconciler(t *testing.T) {
 				of: ClaimKind(MockGVK(&MockClaim{})),
 				to: ClassKind(MockGVK(&MockClass{})),
 			},
-			want: want{result: reconcile.Result{Requeue: false}},
+			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
 		},
 		"UpdateClaimError": {
 			args: args{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #57 

Previously if no controller could schedule or default new claims they would never try again.


### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml