### PR TITLE
Don't update claim statuses after they've been deleted

### DIFF
--- a/pkg/resource/claim_binding_reconciler.go
+++ b/pkg/resource/claim_binding_reconciler.go
@@ -357,12 +357,11 @@ func (r *ClaimReconciler) Reconcile(req reconcile.Request) (reconcile.Result, er
 			return reconcile.Result{RequeueAfter: aShortWait}, errors.Wrap(r.client.Status().Update(ctx, claim), errUpdateClaimStatus)
 		}
 
-		// We've successfully processed the delete, so there's no further
-		// reconciliation to do. There's a good chance our claim no longer
-		// exists, but we try update its status just in case it sticks around,
-		// for example due to additional finalizers.
-		claim.SetConditions(v1alpha1.Deleting(), v1alpha1.ReconcileSuccess())
-		return reconcile.Result{Requeue: false}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+		// We've successfully deleted our claim and removed our finalizer. If we
+		// assume we were the only controller that added a finalizer to this
+		// claim then it should no longer exist and thus there is no point
+		// trying to update its status.
+		return reconcile.Result{Requeue: false}, nil
 	}
 
 	// Claim reconcilers (should) watch for either claims with a resource ref,

--- a/pkg/resource/claim_binding_reconciler_test.go
+++ b/pkg/resource/claim_binding_reconciler_test.go
@@ -289,15 +289,6 @@ func TestClaimReconciler(t *testing.T) {
 								return errUnexpected
 							}
 						}),
-						MockStatusUpdate: test.NewMockStatusUpdateFn(nil, func(got runtime.Object) error {
-							want := &MockClaim{}
-							want.SetDeletionTimestamp(&now)
-							want.SetConditions(v1alpha1.Deleting(), v1alpha1.ReconcileSuccess())
-							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
-								t.Errorf("-want, +got:\n%s", diff)
-							}
-							return nil
-						}),
 					},
 					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Unless someone else added a finalizer (and didn't yet remove it) the claim will cease to exist as soon as the finalizer is removed, so there's nothing to update. This is the claim equivalent of the change we made to the managed resource reconciler in https://github.com/crossplaneio/crossplane-runtime/pull/68.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml