### PR TITLE
Have claim reconciler default to using the status subresource

### DIFF
--- a/pkg/resource/claim_binding_reconciler.go
+++ b/pkg/resource/claim_binding_reconciler.go
@@ -212,7 +212,7 @@ type crClaim struct {
 func defaultCRClaim(m manager.Manager) crClaim {
 	return crClaim{
 		ClaimFinalizer: NewAPIClaimFinalizer(m.GetClient(), claimFinalizerName),
-		Binder:         NewAPIBinder(m.GetClient(), m.GetScheme()),
+		Binder:         NewAPIStatusBinder(m.GetClient(), m.GetScheme()),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #29

All resource claims use the status subresource, but at the time the claim reconciler was introduced most managed resources did not. This is no longer true - all managed resources use the status subresource with the exception of a few stragglers.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml