### PR TITLE
Don't set controller references for dynamically provisioned resources

### DIFF
--- a/pkg/resource/claim_binding_reconciler.go
+++ b/pkg/resource/claim_binding_reconciler.go
@@ -198,7 +198,7 @@ type crManaged struct {
 
 func defaultCRManaged(m manager.Manager) crManaged {
 	return crManaged{
-		ManagedConfigurator:         NewObjectMetaConfigurator(m.GetScheme()),
+		ManagedConfigurator:         ManagedConfiguratorFn(ConfigureNames),
 		ManagedCreator:              NewAPIManagedCreator(m.GetClient(), m.GetScheme()),
 		ManagedConnectionPropagator: NewAPIManagedConnectionPropagator(m.GetClient(), m.GetScheme()),
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Resource claims are namespaced, but the managed resources they dynamically provision are cluster scoped. A namespaced resource cannot, by design, own a cluster scoped resource. This has been a known issue for a long time, but we recently learned that it can result in the managed resources being unintentionally garbage collected by Kubernetes per https://github.com/crossplaneio/stack-gcp/issues/99.

Resource claims and managed resources already reference each other via their resourceRef and claimRef; we had set the owner reference purely to delete dynamically provisioned managed resources along with their claim. Dynamically provisioned managed resources will now always stick around until explicitly cleaned up. We intend to address this by repurposing the existing reclaimPolicy field per https://github.com/crossplaneio/crossplane-runtime/issues/21

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml