### PR TITLE
Mirror PersistentVolume ReclaimPolicy semantics

### DIFF
--- a/apis/core/v1alpha1/bindingphase.go
+++ b/apis/core/v1alpha1/bindingphase.go
@@ -36,6 +36,11 @@ const (
 
 	// BindingPhaseBound resources are bound to another resource.
 	BindingPhaseBound BindingPhase = "Bound"
+
+	// BindingPhaseReleased managed resources were bound to a resource claim
+	// that has since been deleted. Released managed resources cannot be
+	// reclaimed; they are retained to allow manual clean-up and deletion.
+	BindingPhaseReleased BindingPhase = "Released"
 )
 
 // A BindingStatus represents the bindability and binding status of a resource.
@@ -46,7 +51,7 @@ type BindingStatus struct {
 	// available for binding, and Bound resources have successfully bound to
 	// another resource.
 	// +optional
-	// +kubebuilder:validation:Enum=Unbindable;Unbound;Bound
+	// +kubebuilder:validation:Enum=Unbindable;Unbound;Bound;Released
 	Phase BindingPhase `json:"bindingPhase,omitempty"`
 }
 

--- a/apis/core/v1alpha1/policies.go
+++ b/apis/core/v1alpha1/policies.go
@@ -21,11 +21,12 @@ package v1alpha1
 type ReclaimPolicy string
 
 const (
-	// ReclaimDelete means the managed resource will be deleted when its bound
-	// resource claim is deleted.
+	// ReclaimDelete means both the managed resource and its underlying external
+	// resource will be deleted when its bound resource claim is deleted.
 	ReclaimDelete ReclaimPolicy = "Delete"
 
-	// ReclaimRetain means the managed resource will remain when its bound
-	// resource claim is deleted.
+	// ReclaimRetain means the managed resource will retained when its bound
+	// resource claim is deleted. Furthermore, its underlying external resource
+	// will be retained when the managed resource is deleted.
 	ReclaimRetain ReclaimPolicy = "Retain"
 )

--- a/apis/core/v1alpha1/resource.go
+++ b/apis/core/v1alpha1/resource.go
@@ -150,13 +150,18 @@ type ResourceSpec struct {
 	// observe, update, and delete this managed resource.
 	ProviderReference *corev1.ObjectReference `json:"providerRef"`
 
-	// ReclaimPolicy specifies what will happen to the external resource this
-	// managed resource manages when the managed resource is deleted. "Delete"
-	// deletes the external resource, while "Retain" (the default) does not.
-	// Note this behaviour is subtly different from other uses of the
-	// ReclaimPolicy concept within the Kubernetes ecosystem per
-	// https://github.com/crossplaneio/crossplane-runtime/issues/21
+	// ReclaimPolicy specifies what will happen to this managed resource when
+	// its resource claim is deleted, and what will happen to the underlying
+	// external resource when the managed resource is deleted. The "Delete"
+	// policy causes the managed resource to be deleted when its bound resource
+	// claim is deleted, and in turn causes the external resource to be deleted
+	// when its managed resource is deleted. The "Retain" policy causes the
+	// managed resource to be retained, in binding phase "Released", when its
+	// resource claim is deleted, and in turn causes the external resource to be
+	// retained when its managed resource is deleted. The "Retain" policy is
+	// used when no policy is specified.
 	// +optional
+	// +kubebuilder:validation:Enum=Retain;Delete
 	ReclaimPolicy ReclaimPolicy `json:"reclaimPolicy,omitempty"`
 }
 
@@ -180,12 +185,18 @@ type ClassSpecTemplate struct {
 	// provisioned using this resource class.
 	ProviderReference *corev1.ObjectReference `json:"providerRef"`
 
-	// ReclaimPolicy specifies what will happen to external resources when
-	// managed resources dynamically provisioned using this resource class are
-	// deleted. "Delete" deletes the external resource, while "Retain" (the
-	// default) does not. Note this behaviour is subtly different from other
-	// uses of the ReclaimPolicy concept within the Kubernetes ecosystem per
-	// https://github.com/crossplaneio/crossplane-runtime/issues/21
+	// ReclaimPolicy specifies what will happen to managed resources dynamically
+	// provisioned using this class when their resource claims are deleted, and
+	// what will happen to their underlying external resource when they are
+	// deleted. The "Delete" policy causes the managed resource to be deleted
+	// when its bound resource claim is deleted, and in turn causes the external
+	// resource to be deleted when its managed resource is deleted. The "Retain"
+	// policy causes the managed resource to be retained, in binding phase
+	// "Released", when its resource claim is deleted, and in turn causes the
+	// external resource to be retained when its managed resource is deleted.
+	// The "Retain" policy is used when no policy is specified, however the
+	// "Delete" policy is set at dynamic provisioning time if no policy is set.
 	// +optional
+	// +kubebuilder:validation:Enum=Retain;Delete
 	ReclaimPolicy ReclaimPolicy `json:"reclaimPolicy,omitempty"`
 }

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -769,7 +769,7 @@ func TestUnbind(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"Successful": {
+		"SuccessfulRetain": {
 			client: &test.MockClient{
 				MockUpdate: test.NewMockUpdateFn(nil),
 			},
@@ -785,7 +785,29 @@ func TestUnbind(t *testing.T) {
 				err: nil,
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
+					MockClaimReferencer: MockClaimReferencer{Ref: nil},
+				},
+			},
+		},
+		"SuccessfulDelete": {
+			client: &test.MockClient{
+				MockUpdate: test.NewMockUpdateFn(nil),
+				MockDelete: test.NewMockDeleteFn(nil),
+			},
+			args: args{
+				ctx: context.Background(),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
+					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
+				},
+			},
+			want: want{
+				err: nil,
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -806,7 +828,29 @@ func TestUnbind(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
+					MockClaimReferencer: MockClaimReferencer{Ref: nil},
+				},
+			},
+		},
+		"DeleteError": {
+			client: &test.MockClient{
+				MockUpdate: test.NewMockUpdateFn(nil),
+				MockDelete: test.NewMockDeleteFn(errBoom),
+			},
+			args: args{
+				ctx: context.Background(),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
+					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errDeleteManaged),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -846,7 +890,7 @@ func TestStatusUnbind(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"Successful": {
+		"SuccessfulRetain": {
 			client: &test.MockClient{
 				MockUpdate:       test.NewMockUpdateFn(nil),
 				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
@@ -861,7 +905,30 @@ func TestStatusUnbind(t *testing.T) {
 			want: want{
 				err: nil,
 				mg: &MockManaged{
-					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
+					MockClaimReferencer: MockClaimReferencer{Ref: nil},
+				},
+			},
+		},
+		"SuccessfulDelete": {
+			client: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+				MockDelete:       test.NewMockDeleteFn(nil),
+			},
+			args: args{
+				ctx: context.Background(),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
+					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
+				},
+			},
+			want: want{
+				err: nil,
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},
@@ -902,7 +969,30 @@ func TestStatusUnbind(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManagedStatus),
 				mg: &MockManaged{
 					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimRetain},
-					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseUnbound},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
+					MockClaimReferencer: MockClaimReferencer{Ref: nil},
+				},
+			},
+		},
+		"DeleteError": {
+			client: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+				MockDelete:       test.NewMockDeleteFn(errBoom),
+			},
+			args: args{
+				ctx: context.Background(),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
+					MockClaimReferencer: MockClaimReferencer{Ref: &corev1.ObjectReference{}},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errDeleteManaged),
+				mg: &MockManaged{
+					MockReclaimer:       MockReclaimer{Policy: v1alpha1.ReclaimDelete},
+					BindingStatus:       v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased},
 					MockClaimReferencer: MockClaimReferencer{Ref: nil},
 				},
 			},

--- a/pkg/resource/claim_binding_reconciler.go
+++ b/pkg/resource/claim_binding_reconciler.go
@@ -198,7 +198,10 @@ type crManaged struct {
 
 func defaultCRManaged(m manager.Manager) crManaged {
 	return crManaged{
-		ManagedConfigurator:         ManagedConfiguratorFn(ConfigureNames),
+		ManagedConfigurator: ConfiguratorChain{
+			ManagedConfiguratorFn(ConfigureNames),
+			ManagedConfiguratorFn(ConfigureReclaimPolicy),
+		},
 		ManagedCreator:              NewAPIManagedCreator(m.GetClient(), m.GetScheme()),
 		ManagedConnectionPropagator: NewAPIManagedConnectionPropagator(m.GetClient(), m.GetScheme()),
 	}

--- a/pkg/resource/configurator.go
+++ b/pkg/resource/configurator.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
 )
 
@@ -63,6 +64,26 @@ func ConfigureNames(_ context.Context, cm Claim, _ Class, mg Managed) error {
 	mg.SetGenerateName(fmt.Sprintf("%s-%s-", cm.GetNamespace(), cm.GetName()))
 	if meta.GetExternalName(cm) != "" {
 		meta.SetExternalName(mg, meta.GetExternalName(cm))
+	}
+
+	return nil
+}
+
+// ConfigureReclaimPolicy configures the reclaim policy of the supplied managed
+// resource. If the managed resource _already has_ a reclaim policy (for example
+// because one was set by another configurator) it is respected. Otherwise the
+// reclaim policy is copied from the resource class. If the resource class does
+// not specify a reclaim policy, the managed resource's policy is set to
+// "Delete".
+func ConfigureReclaimPolicy(_ context.Context, _ Claim, cs Class, mg Managed) error {
+	if mg.GetReclaimPolicy() != "" {
+		return nil
+	}
+
+	mg.SetReclaimPolicy(cs.GetReclaimPolicy())
+
+	if mg.GetReclaimPolicy() == "" {
+		mg.SetReclaimPolicy(v1alpha1.ReclaimDelete)
 	}
 
 	return nil

--- a/pkg/resource/managed_reconciler.go
+++ b/pkg/resource/managed_reconciler.go
@@ -490,8 +490,6 @@ func (r *ManagedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, 
 	}
 
 	if meta.WasDeleted(managed) {
-		// TODO(muvaf): Reclaim Policy should be used between Claim and Managed.
-		// For Managed and External Resource, we need another field.
 		if observation.ResourceExists && managed.GetReclaimPolicy() == v1alpha1.ReclaimDelete {
 			if err := external.Delete(ctx, managed); err != nil {
 				// We'll hit this condition if we can't delete our external

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -142,12 +142,16 @@ func ResolveClassClaimValues(classValue, claimValue string) (string, error) {
 }
 
 // SetBindable indicates that the supplied Bindable is ready for binding to
-// another Bindable, such as a resource claim or managed resource.
+// another Bindable, such as a resource claim or managed resource by setting its
+// binding phase to "Unbound". It is a no-op for Bindables in phases "Bound" or
+// "Released", because these phases may not transition back to "Unbound".
 func SetBindable(b Bindable) {
-	if b.GetBindingPhase() == v1alpha1.BindingPhaseBound {
+	switch b.GetBindingPhase() {
+	case v1alpha1.BindingPhaseBound, v1alpha1.BindingPhaseReleased:
 		return
+	default:
+		b.SetBindingPhase(v1alpha1.BindingPhaseUnbound)
 	}
-	b.SetBindingPhase(v1alpha1.BindingPhaseUnbound)
 }
 
 // IsBindable returns true if the supplied Bindable is ready for binding to

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -387,6 +387,10 @@ func TestSetBindable(t *testing.T) {
 			b:    &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 			want: v1alpha1.BindingPhaseBound,
 		},
+		"BindableIsReleased": {
+			b:    &MockClaim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseReleased}},
+			want: v1alpha1.BindingPhaseReleased,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #21 

This commit changes the meaning of the managed resource reclaim policy to match https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming as closely as possible, minus the deprecated 'Recycle' policy. Previously the reclaim policy dictated only what happened to the external resource when its managed resource was deleted.

Note that the implementation here differs slightly from some of our discussions around the reclaim policy, but I believe that is due to our having misunderstood how the persistent volume reclaim policy that we wanted to mirror works. Based on my read of the above link, the behaviour I intend for this PR is:

* Managed resources using the `Delete` policy are deleted when their bound resource claim is deleted.
* Managed resources using the `Delete` policy delete their external resource when they are deleted.
* Managed resources using the `Retain` policy are _not_ deleted when their bound resource claim is deleted.
* Managed resources using the `Retain` policy do _not_ delete their external resource when they are deleted.
* All managed resources transition to binding phase `Released` (not `Unbound`) when their resource claim is deleted.
* A `Released` managed resource cannot be reused; it sticks around only so the infrastructure operator can perform any cleanup tasks they need to before manually deleting it.
* A managed resource without a reclaim policy defaults to `Retain`, in that the absence of a reclaim policy is treated as `Retain`.
* A resource class without a reclaim policy will dynamically provision managed resources with the `Delete` reclaim policy.

### Testing Checklist

Before merging this PR I intend to:

- [x] Ensure statically provisioned managed resources default to `Retain` by dynamically provisioning a managed resource without a reclaim policy and observing that the managed resource's reclaim policy is unset.
- [x] Ensure dynamically provisioned managed resources default to `Delete` by dynamically provisioning a managed resource using a resource claim without a resource policy and observing that the managed resource's reclaim policy is `Delete`.
- [x] Ensure managed resources with policy `Retain` (or unset) are retained in binding phase `Released` when their claim is deleted.
- [x] Ensure managed resources with policy `Retain` (or unset) retain their external resources when deleted.
- [x] Ensure managed resources with policy `Delete` are deleted when their claim is deleted.
- [x] Ensure managed resources with policy `Delete` delete their external resources when deleted.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml