### PR TITLE
secret reconciler: allow for propagation to multiple secrets

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -126,7 +125,9 @@ func (a *APIManagedConnectionPropagator) PropagateConnection(ctx context.Context
 		}
 		cmcs.Data = mgcs.Data
 		meta.AddAnnotations(cmcs, map[string]string{
-			fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(mgcs.GetUID())): strings.Join([]string{mgcs.GetNamespace(), mgcs.GetName()}, "/"),
+			AnnotationKeyPropagateFromNamespace: mgcs.GetNamespace(),
+			AnnotationKeyPropagateFromName:      mgcs.GetName(),
+			AnnotationKeyPropagateFromUID:       string(mgcs.GetUID()),
 		})
 		return nil
 	}); err != nil {
@@ -134,7 +135,7 @@ func (a *APIManagedConnectionPropagator) PropagateConnection(ctx context.Context
 	}
 
 	meta.AddAnnotations(mgcs, map[string]string{
-		fmt.Sprintf(AnnotationKeyPropagateToFormat, string(cmcs.GetUID())): strings.Join([]string{cmcs.GetNamespace(), cmcs.GetName()}, "/"),
+		strings.Join([]string{AnnotationKeyPropagateToPrefix, string(cmcs.GetUID())}, SlashDelimeter): strings.Join([]string{cmcs.GetNamespace(), cmcs.GetName()}, SlashDelimeter),
 	})
 
 	return errors.Wrap(a.client.Update(ctx, mgcs), errUpdateSecret)

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -18,6 +18,8 @@ package resource
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -124,9 +126,7 @@ func (a *APIManagedConnectionPropagator) PropagateConnection(ctx context.Context
 		}
 		cmcs.Data = mgcs.Data
 		meta.AddAnnotations(cmcs, map[string]string{
-			AnnotationKeyPropagateFromNamespace: mgcs.GetNamespace(),
-			AnnotationKeyPropagateFromName:      mgcs.GetName(),
-			AnnotationKeyPropagateFromUID:       string(mgcs.GetUID()),
+			fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(mgcs.GetUID())): strings.Join([]string{mgcs.GetNamespace(), mgcs.GetName()}, "/"),
 		})
 		return nil
 	}); err != nil {
@@ -134,9 +134,7 @@ func (a *APIManagedConnectionPropagator) PropagateConnection(ctx context.Context
 	}
 
 	meta.AddAnnotations(mgcs, map[string]string{
-		AnnotationKeyPropagateToNamespace: cmcs.GetNamespace(),
-		AnnotationKeyPropagateToName:      cmcs.GetName(),
-		AnnotationKeyPropagateToUID:       string(cmcs.GetUID()),
+		fmt.Sprintf(AnnotationKeyPropagateToFormat, string(cmcs.GetUID())): strings.Join([]string{cmcs.GetNamespace(), cmcs.GetName()}, "/"),
 	})
 
 	return errors.Wrap(a.client.Update(ctx, mgcs), errUpdateSecret)

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -18,6 +18,8 @@ package resource
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -394,9 +396,7 @@ func TestPropagateConnection(t *testing.T) {
 						case cmcsname:
 							want.SetName(cmcsname)
 							want.SetAnnotations(map[string]string{
-								AnnotationKeyPropagateFromNamespace: namespace,
-								AnnotationKeyPropagateFromName:      mgcsname,
-								AnnotationKeyPropagateFromUID:       string(uid),
+								fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(uid)): strings.Join([]string{namespace, mgcsname}, "/"),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -404,9 +404,82 @@ func TestPropagateConnection(t *testing.T) {
 						case mgcsname:
 							want.SetName(mgcsname)
 							want.SetAnnotations(map[string]string{
-								AnnotationKeyPropagateToNamespace: namespace,
-								AnnotationKeyPropagateToName:      cmcsname,
-								AnnotationKeyPropagateToUID:       string(uid),
+								fmt.Sprintf(AnnotationKeyPropagateToFormat, string(uid)): strings.Join([]string{namespace, cmcsname}, "/"),
+							})
+							if diff := cmp.Diff(want, got); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+						default:
+							return errors.New("unexpected secret name")
+						}
+						return nil
+					}),
+				},
+				typer: fake.SchemeWith(&fake.Claim{}, &fake.Managed{}),
+			},
+			args: args{
+				ctx: context.Background(),
+				cm: &fake.Claim{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: cmname, UID: uid},
+					LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
+						Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
+					},
+				},
+				mg: &fake.Managed{
+					ObjectMeta: metav1.ObjectMeta{Name: mgname, UID: uid},
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
+						Ref: &v1alpha1.SecretReference{Namespace: mgcsnamespace, Name: mgcsname},
+					},
+				},
+			},
+			want: nil,
+		},
+		"SuccessfulWithExisting": {
+			fields: fields{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, n types.NamespacedName, o runtime.Object) error {
+						s := corev1.Secret{}
+						s.SetNamespace(namespace)
+						s.SetUID(uid)
+						s.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
+
+						switch n.Name {
+						case mgcsname:
+							s.SetName(mgcsname)
+							meta.AddAnnotations(&s, map[string]string{
+								fmt.Sprintf(AnnotationKeyPropagateToFormat, "existing-uid"): "existing-namespace/existing-name",
+							})
+							s.Data = mgcsdata
+							*o.(*corev1.Secret) = s
+						case cmcsname:
+							s.SetName(cmcsname)
+							*o.(*corev1.Secret) = s
+						default:
+							return errors.New("unexpected secret name")
+						}
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil, func(got runtime.Object) error {
+						want := &corev1.Secret{}
+						want.SetNamespace(namespace)
+						want.SetUID(uid)
+						want.SetOwnerReferences([]metav1.OwnerReference{{UID: uid, Controller: &controller}})
+						want.Data = mgcsdata
+
+						switch got.(metav1.Object).GetName() {
+						case cmcsname:
+							want.SetName(cmcsname)
+							want.SetAnnotations(map[string]string{
+								fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(uid)): strings.Join([]string{namespace, mgcsname}, "/"),
+							})
+							if diff := cmp.Diff(want, got); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+						case mgcsname:
+							want.SetName(mgcsname)
+							want.SetAnnotations(map[string]string{
+								fmt.Sprintf(AnnotationKeyPropagateToFormat, "existing-uid"): "existing-namespace/existing-name",
+								fmt.Sprintf(AnnotationKeyPropagateToFormat, string(uid)):    strings.Join([]string{namespace, cmcsname}, "/"),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -563,7 +563,7 @@ func TestBind(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				cm:  &fake.Claim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -595,7 +595,7 @@ func TestBind(t *testing.T) {
 				},
 				mg: &fake.Managed{
 					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -612,7 +612,7 @@ func TestBind(t *testing.T) {
 				err: nil,
 				cm:  &fake.Claim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -634,7 +634,7 @@ func TestBind(t *testing.T) {
 					BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
 					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -699,7 +699,7 @@ func TestStatusBind(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManaged),
 				cm:  &fake.Claim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 				},
 			},
 		},
@@ -718,7 +718,7 @@ func TestStatusBind(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateManagedStatus),
 				cm:  &fake.Claim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -753,7 +753,7 @@ func TestStatusBind(t *testing.T) {
 				},
 				mg: &fake.Managed{
 					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -773,7 +773,7 @@ func TestStatusBind(t *testing.T) {
 				err: nil,
 				cm:  &fake.Claim{BindingStatus: v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound}},
 				mg: &fake.Managed{
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},
@@ -799,7 +799,7 @@ func TestStatusBind(t *testing.T) {
 				},
 				mg: &fake.Managed{
 					ObjectMeta:      metav1.ObjectMeta{Annotations: map[string]string{meta.ExternalNameAnnotationKey: externalName}},
-					ClaimReferencer: fake.ClaimReferencer{meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
+					ClaimReferencer: fake.ClaimReferencer{Ref: meta.ReferenceTo(&fake.Claim{}, fake.GVK(&fake.Claim{}))},
 					BindingStatus:   v1alpha1.BindingStatus{Phase: v1alpha1.BindingPhaseBound},
 				},
 			},

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -396,7 +395,9 @@ func TestPropagateConnection(t *testing.T) {
 						case cmcsname:
 							want.SetName(cmcsname)
 							want.SetAnnotations(map[string]string{
-								fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(uid)): strings.Join([]string{namespace, mgcsname}, "/"),
+								AnnotationKeyPropagateFromNamespace: namespace,
+								AnnotationKeyPropagateFromName:      mgcsname,
+								AnnotationKeyPropagateFromUID:       string(uid),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -404,7 +405,7 @@ func TestPropagateConnection(t *testing.T) {
 						case mgcsname:
 							want.SetName(mgcsname)
 							want.SetAnnotations(map[string]string{
-								fmt.Sprintf(AnnotationKeyPropagateToFormat, string(uid)): strings.Join([]string{namespace, cmcsname}, "/"),
+								strings.Join([]string{AnnotationKeyPropagateToPrefix, string(uid)}, SlashDelimeter): strings.Join([]string{namespace, cmcsname}, SlashDelimeter),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -447,7 +448,7 @@ func TestPropagateConnection(t *testing.T) {
 						case mgcsname:
 							s.SetName(mgcsname)
 							meta.AddAnnotations(&s, map[string]string{
-								fmt.Sprintf(AnnotationKeyPropagateToFormat, "existing-uid"): "existing-namespace/existing-name",
+								strings.Join([]string{AnnotationKeyPropagateToPrefix, "existing-uid"}, SlashDelimeter): "existing-namespace/existing-name",
 							})
 							s.Data = mgcsdata
 							*o.(*corev1.Secret) = s
@@ -470,7 +471,9 @@ func TestPropagateConnection(t *testing.T) {
 						case cmcsname:
 							want.SetName(cmcsname)
 							want.SetAnnotations(map[string]string{
-								fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(uid)): strings.Join([]string{namespace, mgcsname}, "/"),
+								AnnotationKeyPropagateFromNamespace: namespace,
+								AnnotationKeyPropagateFromName:      mgcsname,
+								AnnotationKeyPropagateFromUID:       string(uid),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -478,8 +481,8 @@ func TestPropagateConnection(t *testing.T) {
 						case mgcsname:
 							want.SetName(mgcsname)
 							want.SetAnnotations(map[string]string{
-								fmt.Sprintf(AnnotationKeyPropagateToFormat, "existing-uid"): "existing-namespace/existing-name",
-								fmt.Sprintf(AnnotationKeyPropagateToFormat, string(uid)):    strings.Join([]string{namespace, cmcsname}, "/"),
+								strings.Join([]string{AnnotationKeyPropagateToPrefix, "existing-uid"}, SlashDelimeter): "existing-namespace/existing-name",
+								strings.Join([]string{AnnotationKeyPropagateToPrefix, string(uid)}, SlashDelimeter):    strings.Join([]string{namespace, cmcsname}, SlashDelimeter),
 							})
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)

--- a/pkg/resource/enqueue_handlers.go
+++ b/pkg/resource/enqueue_handlers.go
@@ -106,25 +106,23 @@ func addPropagated(obj runtime.Object, queue adder) {
 	a := ao.GetAnnotations()
 
 	for key, val := range a {
-		if strings.HasPrefix(key, AnnotationKeyPropagateTo) {
-			t := strings.Split(val, "/")
-			if len(t) != 2 {
-				continue
-			}
-			toNamespace := t[0]
-			toName := t[1]
-
-			switch {
-			case toName == "":
-				continue
-			case toNamespace == "":
-				continue
-			default:
-				queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-					Namespace: toNamespace,
-					Name:      toName,
-				}})
-			}
+		if !strings.HasPrefix(key, AnnotationKeyPropagateToPrefix) {
+			continue
+		}
+		t := strings.Split(val, SlashDelimeter)
+		if len(t) != 2 {
+			continue
+		}
+		switch {
+		case t[0] == "":
+			continue
+		case t[1] == "":
+			continue
+		default:
+			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: t[0],
+				Name:      t[1],
+			}})
 		}
 	}
 }

--- a/pkg/resource/enqueue_handlers.go
+++ b/pkg/resource/enqueue_handlers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -65,52 +67,64 @@ func addClaim(obj runtime.Object, queue adder) {
 	}
 }
 
-// EnqueueRequestForPropagator enqueues a reconcile.Request for the
+// EnqueueRequestForPropagated enqueues a reconcile.Request for the
 // NamespacedName of a propagated object, i.e. an object with propagation
 // metadata annotations.
-type EnqueueRequestForPropagator struct{}
+type EnqueueRequestForPropagated struct{}
 
 // Create adds a NamespacedName for the supplied CreateEvent if its Object is
 // propagated.
-func (e *EnqueueRequestForPropagator) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	addPropagator(evt.Object, q)
+func (e *EnqueueRequestForPropagated) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	addPropagated(evt.Object, q)
 }
 
 // Update adds a NamespacedName for the supplied UpdateEvent if its Objects are
 // propagated.
-func (e *EnqueueRequestForPropagator) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	addPropagator(evt.ObjectOld, q)
-	addPropagator(evt.ObjectNew, q)
+func (e *EnqueueRequestForPropagated) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	addPropagated(evt.ObjectOld, q)
+	addPropagated(evt.ObjectNew, q)
 }
 
 // Delete adds a NamespacedName for the supplied DeleteEvent if its Object is
 // propagated.
-func (e *EnqueueRequestForPropagator) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	addPropagator(evt.Object, q)
+func (e *EnqueueRequestForPropagated) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	addPropagated(evt.Object, q)
 }
 
 // Generic adds a NamespacedName for the supplied GenericEvent if its Object is
 // propagated.
-func (e *EnqueueRequestForPropagator) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	addPropagator(evt.Object, q)
+func (e *EnqueueRequestForPropagated) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	addPropagated(evt.Object, q)
 }
 
-func addPropagator(obj runtime.Object, queue adder) {
+func addPropagated(obj runtime.Object, queue adder) {
 	ao, ok := obj.(annotated)
 	if !ok {
 		return
 	}
 
 	a := ao.GetAnnotations()
-	switch {
-	case a[AnnotationKeyPropagateFromNamespace] == "":
-		return
-	case a[AnnotationKeyPropagateFromName] == "":
-		return
-	default:
-		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-			Namespace: a[AnnotationKeyPropagateFromNamespace],
-			Name:      a[AnnotationKeyPropagateFromName],
-		}})
+
+	for key, val := range a {
+		if strings.HasPrefix(key, AnnotationKeyPropagateTo) {
+			t := strings.Split(val, "/")
+			if len(t) != 2 {
+				continue
+			}
+			toNamespace := t[0]
+			toName := t[1]
+
+			switch {
+			case toName == "":
+				continue
+			case toNamespace == "":
+				continue
+			default:
+				queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: toNamespace,
+					Name:      toName,
+				}})
+			}
+		}
 	}
 }

--- a/pkg/resource/enqueue_handlers_test.go
+++ b/pkg/resource/enqueue_handlers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resource
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -88,7 +87,7 @@ func TestAddPropagated(t *testing.T) {
 		"ObjectIsNotAnnotated": {
 			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
 		},
-		"ObjectMissing" + AnnotationKeyPropagateTo: {
+		"ObjectMissing" + AnnotationKeyPropagateToPrefix: {
 			obj: &fake.Managed{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				"some.annotation": "some-value",
 			}}},
@@ -96,7 +95,7 @@ func TestAddPropagated(t *testing.T) {
 		},
 		"IsPropagatorObject": {
 			obj: &fake.Managed{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				fmt.Sprintf(AnnotationKeyPropagateToFormat, uid): strings.Join([]string{ns, name}, "/"),
+				strings.Join([]string{AnnotationKeyPropagateToPrefix, uid}, SlashDelimeter): strings.Join([]string{ns, name}, SlashDelimeter),
 			}}},
 			queue: addFn(func(got interface{}) {
 				want := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}

--- a/pkg/resource/enqueue_handlers_test.go
+++ b/pkg/resource/enqueue_handlers_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -74,9 +76,10 @@ func TestAddClaim(t *testing.T) {
 	}
 }
 
-func TestAddPropagator(t *testing.T) {
+func TestAddPropagated(t *testing.T) {
 	ns := "coolns"
 	name := "coolname"
+	uid := "a-cool-uid"
 
 	cases := map[string]struct {
 		obj   runtime.Object
@@ -85,22 +88,15 @@ func TestAddPropagator(t *testing.T) {
 		"ObjectIsNotAnnotated": {
 			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
 		},
-		"ObjectMissing" + AnnotationKeyPropagateFromNamespace: {
+		"ObjectMissing" + AnnotationKeyPropagateTo: {
 			obj: &fake.Managed{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromName: name,
+				"some.annotation": "some-value",
 			}}},
 			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
 		},
-		"ObjectMissing" + AnnotationKeyPropagateFromName: {
+		"IsPropagatorObject": {
 			obj: &fake.Managed{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromNamespace: ns,
-			}}},
-			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
-		},
-		"IsPropagatedObject": {
-			obj: &fake.Managed{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromNamespace: ns,
-				AnnotationKeyPropagateFromName:      name,
+				fmt.Sprintf(AnnotationKeyPropagateToFormat, uid): strings.Join([]string{ns, name}, "/"),
 			}}},
 			queue: addFn(func(got interface{}) {
 				want := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
@@ -112,6 +108,6 @@ func TestAddPropagator(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		addPropagator(tc.obj, tc.queue)
+		addPropagated(tc.obj, tc.queue)
 	}
 }

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resource
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -135,16 +137,13 @@ func IsPropagator() PredicateFn {
 		}
 
 		a := ao.GetAnnotations()
-		switch {
-		case a[AnnotationKeyPropagateToNamespace] == "":
-			return false
-		case a[AnnotationKeyPropagateToName] == "":
-			return false
-		case a[AnnotationKeyPropagateToUID] == "":
-			return false
-		default:
-			return true
+		for key := range a {
+			if strings.HasPrefix(key, AnnotationKeyPropagateTo) {
+				return true
+			}
 		}
+
+		return false
 	}
 }
 
@@ -158,16 +157,13 @@ func IsPropagated() PredicateFn {
 		}
 
 		a := ao.GetAnnotations()
-		switch {
-		case a[AnnotationKeyPropagateFromNamespace] == "":
-			return false
-		case a[AnnotationKeyPropagateFromName] == "":
-			return false
-		case a[AnnotationKeyPropagateFromUID] == "":
-			return false
-		default:
-			return true
+		for key := range a {
+			if strings.HasPrefix(key, AnnotationKeyPropagateFrom) {
+				return true
+			}
 		}
+
+		return false
 	}
 }
 

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -136,9 +136,8 @@ func IsPropagator() PredicateFn {
 			return false
 		}
 
-		a := ao.GetAnnotations()
-		for key := range a {
-			if strings.HasPrefix(key, AnnotationKeyPropagateTo) {
+		for key := range ao.GetAnnotations() {
+			if strings.HasPrefix(key, AnnotationKeyPropagateToPrefix) {
 				return true
 			}
 		}
@@ -157,13 +156,16 @@ func IsPropagated() PredicateFn {
 		}
 
 		a := ao.GetAnnotations()
-		for key := range a {
-			if strings.HasPrefix(key, AnnotationKeyPropagateFrom) {
-				return true
-			}
+		switch {
+		case a[AnnotationKeyPropagateFromNamespace] == "":
+			return false
+		case a[AnnotationKeyPropagateFromName] == "":
+			return false
+		case a[AnnotationKeyPropagateFromUID] == "":
+			return false
+		default:
+			return true
 		}
-
-		return false
 	}
 }
 

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -291,14 +291,14 @@ func TestIsPropagator(t *testing.T) {
 		},
 		"IsPropagator": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateTo + "cool-uid": "cool-namespace/cool-name",
+				AnnotationKeyPropagateToPrefix + "cool-uid": "cool-namespace/cool-name",
 			}}},
 			want: true,
 		},
 		"IsMultiPropagator": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateTo + "cool-uid":     "cool-namespace/cool-name",
-				AnnotationKeyPropagateTo + "cool-uid-two": "cool-namespace/cool-name-2",
+				AnnotationKeyPropagateToPrefix + "cool-uid":     "cool-namespace/cool-name",
+				AnnotationKeyPropagateToPrefix + "cool-uid-two": "cool-namespace/cool-name-2",
 			}}},
 			want: true,
 		},
@@ -330,7 +330,9 @@ func TestIsPropagated(t *testing.T) {
 		},
 		"IsPropagated": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFrom + "cool-uid": "cool-namespace/cool-name",
+				AnnotationKeyPropagateFromNamespace: namespace,
+				AnnotationKeyPropagateFromName:      name,
+				AnnotationKeyPropagateFromUID:       string(uid),
 			}}},
 			want: true,
 		},

--- a/pkg/resource/predicates_test.go
+++ b/pkg/resource/predicates_test.go
@@ -283,32 +283,22 @@ func TestIsPropagator(t *testing.T) {
 		"NotAnAnnotator": {
 			want: false,
 		},
-		"Missing" + AnnotationKeyPropagateToNamespace: {
+		"NotAPropagator": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateToName: name,
-				AnnotationKeyPropagateToUID:  string(uid),
-			}}},
-			want: false,
-		},
-		"Missing" + AnnotationKeyPropagateToName: {
-			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateToNamespace: namespace,
-				AnnotationKeyPropagateToUID:       string(uid),
-			}}},
-			want: false,
-		},
-		"Missing" + AnnotationKeyPropagateToUID: {
-			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateToNamespace: namespace,
-				AnnotationKeyPropagateToName:      name,
+				"some.annotation": "someValue",
 			}}},
 			want: false,
 		},
 		"IsPropagator": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateToNamespace: namespace,
-				AnnotationKeyPropagateToName:      name,
-				AnnotationKeyPropagateToUID:       string(uid),
+				AnnotationKeyPropagateTo + "cool-uid": "cool-namespace/cool-name",
+			}}},
+			want: true,
+		},
+		"IsMultiPropagator": {
+			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+				AnnotationKeyPropagateTo + "cool-uid":     "cool-namespace/cool-name",
+				AnnotationKeyPropagateTo + "cool-uid-two": "cool-namespace/cool-name-2",
 			}}},
 			want: true,
 		},
@@ -332,32 +322,15 @@ func TestIsPropagated(t *testing.T) {
 		"NotAnAnnotator": {
 			want: false,
 		},
-		"Missing" + AnnotationKeyPropagateFromNamespace: {
+		"NotPropagated": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromName: name,
-				AnnotationKeyPropagateFromUID:  string(uid),
-			}}},
-			want: false,
-		},
-		"Missing" + AnnotationKeyPropagateFromName: {
-			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromNamespace: namespace,
-				AnnotationKeyPropagateFromUID:       string(uid),
-			}}},
-			want: false,
-		},
-		"Missing" + AnnotationKeyPropagateFromUID: {
-			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromNamespace: namespace,
-				AnnotationKeyPropagateFromName:      name,
+				"some.annotation": "someValue",
 			}}},
 			want: false,
 		},
 		"IsPropagated": {
 			obj: &corev1.Secret{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
-				AnnotationKeyPropagateFromNamespace: namespace,
-				AnnotationKeyPropagateFromName:      name,
-				AnnotationKeyPropagateFromUID:       string(uid),
+				AnnotationKeyPropagateFrom + "cool-uid": "cool-namespace/cool-name",
 			}}},
 			want: true,
 		},

--- a/pkg/resource/secret_reconciler.go
+++ b/pkg/resource/secret_reconciler.go
@@ -37,9 +37,9 @@ const (
 	AnnotationKeyPropagateToPrefix = "to.propagate.crossplane.io"
 	SlashDelimeter                 = "/"
 
-	AnnotationKeyPropagateFromNamespace = "crossplane.io/propagate-from-namespace"
-	AnnotationKeyPropagateFromName      = "crossplane.io/propagate-from-name"
-	AnnotationKeyPropagateFromUID       = "crossplane.io/propagate-from-uid"
+	AnnotationKeyPropagateFromNamespace = "from.propagate.crossplane.io/namespace"
+	AnnotationKeyPropagateFromName      = "from.propagate.crossplane.io/name"
+	AnnotationKeyPropagateFromUID       = "from.propagate.crossplane.io/uid"
 )
 
 type annotated interface {

--- a/pkg/resource/secret_reconciler.go
+++ b/pkg/resource/secret_reconciler.go
@@ -57,9 +57,7 @@ const (
 // by propagating their data to another secret. Both secrets must consent to
 // this process by including propagation annotations. The Reconciler assumes it
 // has a watch on both propagating (from) and propagated (to) secrets.
-func NewSecretPropagatingReconciler(m manager.Manager) reconcile.Reconciler { // nolint:gocyclo
-	// NOTE(hasheddan): This function is over our cyclomatic complexity goal.
-	// Be wary of adding additional complexity.
+func NewSecretPropagatingReconciler(m manager.Manager) reconcile.Reconciler {
 	client := m.GetClient()
 
 	return reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/resource/secret_reconciler.go
+++ b/pkg/resource/secret_reconciler.go
@@ -57,7 +57,9 @@ const (
 // by propagating their data to another secret. Both secrets must consent to
 // this process by including propagation annotations. The Reconciler assumes it
 // has a watch on both propagating (from) and propagated (to) secrets.
-func NewSecretPropagatingReconciler(m manager.Manager) reconcile.Reconciler {
+func NewSecretPropagatingReconciler(m manager.Manager) reconcile.Reconciler { // nolint:gocyclo
+	// NOTE(hasheddan): This function is over our cyclomatic complexity goal.
+	// Be wary of adding additional complexity.
 	client := m.GetClient()
 
 	return reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/resource/secret_reconciler_test.go
+++ b/pkg/resource/secret_reconciler_test.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -114,7 +113,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 								}
@@ -146,7 +147,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 								}
@@ -179,7 +182,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, "some-other-uid"): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       "some-other-UID",
 										},
 									},
 									Data: fromData,
@@ -191,7 +196,7 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      fromName,
 										UID:       fromUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string(toUID)): strings.Join([]string{ns, toName}, "/"),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, string(toUID)}, SlashDelimeter): strings.Join([]string{ns, toName}, SlashDelimeter),
 										},
 									},
 									Data: fromData,
@@ -227,7 +232,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 									Data: fromData,
@@ -239,7 +246,7 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      fromName,
 										UID:       fromUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, "some-other-uid"): strings.Join([]string{ns, toName}, "/"),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, "some-other-uid"}, SlashDelimeter): strings.Join([]string{ns, toName}, SlashDelimeter),
 										},
 									},
 									Data: fromData,
@@ -275,7 +282,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 									Data: fromData,
@@ -287,7 +296,7 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      fromName,
 										UID:       fromUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string(toUID)): strings.Join([]string{ns, toName}, "/"),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, string(toUID)}, SlashDelimeter): strings.Join([]string{ns, toName}, SlashDelimeter),
 										},
 									},
 									Data: fromData,
@@ -322,7 +331,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 									Data: fromData,
@@ -334,7 +345,7 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      fromName,
 										UID:       fromUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string(toUID)): strings.Join([]string{ns, toName}, "/"),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, string(toUID)}, SlashDelimeter): strings.Join([]string{ns, toName}, SlashDelimeter),
 										},
 									},
 									Data: fromData,
@@ -351,7 +362,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 									Name:      toName,
 									UID:       toUID,
 									Annotations: map[string]string{
-										fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+										AnnotationKeyPropagateFromName:      fromName,
+										AnnotationKeyPropagateFromNamespace: ns,
+										AnnotationKeyPropagateFromUID:       string(fromUID),
 									},
 								},
 								Data: fromData,
@@ -383,7 +396,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      toName,
 										UID:       toUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+											AnnotationKeyPropagateFromName:      fromName,
+											AnnotationKeyPropagateFromNamespace: ns,
+											AnnotationKeyPropagateFromUID:       string(fromUID),
 										},
 									},
 									Data: fromData,
@@ -395,9 +410,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 										Name:      fromName,
 										UID:       fromUID,
 										Annotations: map[string]string{
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string(toUID)):            strings.Join([]string{ns, toName}, "/"),
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string("some-uid")):       strings.Join([]string{ns, toName}, "/"),
-											fmt.Sprintf(AnnotationKeyPropagateToFormat, string("some-other-uid")): strings.Join([]string{ns, toName}, "/"),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, string(toUID)}, SlashDelimeter):    strings.Join([]string{ns, toName}, SlashDelimeter),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, "some-uid"}, SlashDelimeter):       strings.Join([]string{ns, toName}, SlashDelimeter),
+											strings.Join([]string{AnnotationKeyPropagateToPrefix, "some-other-uid"}, SlashDelimeter): strings.Join([]string{ns, toName}, SlashDelimeter),
 										},
 									},
 									Data: fromData,
@@ -414,7 +429,9 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 									Name:      toName,
 									UID:       toUID,
 									Annotations: map[string]string{
-										fmt.Sprintf(AnnotationKeyPropagateFromFormat, string(fromUID)): strings.Join([]string{ns, fromName}, "/"),
+										AnnotationKeyPropagateFromName:      fromName,
+										AnnotationKeyPropagateFromNamespace: ns,
+										AnnotationKeyPropagateFromUID:       string(fromUID),
 									},
 								},
 								Data: fromData,

--- a/pkg/resource/secret_reconciler_test.go
+++ b/pkg/resource/secret_reconciler_test.go
@@ -130,7 +130,6 @@ func TestSecretPropagatingReconciler(t *testing.T) {
 			},
 			want: want{
 				result: reconcile.Result{},
-				err:    errors.Wrap(kerrors.NewNotFound(schema.GroupResource{}, fromName), errGetSecret),
 			},
 		},
 		"GetFromError": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Allows for the secret reconciler to propagate a single `from` secret's data to multiple `to` secrets per https://github.com/crossplaneio/crossplane/pull/1101#discussion_r354505820.

TODO:
- [x] Handle cumulative errors in secret reconciler more elegantly
- [x] Add secret reconciler unit tests that check for multiple error handling

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml