### PR TITLE
Add Provider interface

### DIFF
--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -82,6 +82,13 @@ type Reclaimer interface {
 	GetReclaimPolicy() v1alpha1.ReclaimPolicy
 }
 
+// A CredentialsSecretReferencer may refer to a credential secret in an arbitrary
+// namespace.
+type CredentialsSecretReferencer interface {
+	GetCredentialsSecretReference() *v1alpha1.SecretKeySelector
+	SetCredentialsSecretReference(r *v1alpha1.SecretKeySelector)
+}
+
 // A Claim is a Kubernetes object representing an abstract resource claim (e.g.
 // an SQL database) that may be bound to a concrete managed resource (e.g. a
 // CloudSQL instance).
@@ -120,4 +127,13 @@ type Managed interface {
 
 	Conditioned
 	Bindable
+}
+
+// A Provider is a Kubernetes object that refers to credentials to connect
+// to an external system.
+type Provider interface {
+	runtime.Object
+	metav1.Object
+
+	CredentialsSecretReferencer
 }

--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -80,6 +80,15 @@ type MockReclaimer struct{ Policy v1alpha1.ReclaimPolicy }
 func (m *MockReclaimer) SetReclaimPolicy(p v1alpha1.ReclaimPolicy) { m.Policy = p }
 func (m *MockReclaimer) GetReclaimPolicy() v1alpha1.ReclaimPolicy  { return m.Policy }
 
+type MockCredentialsSecretReferencer struct{ Ref *v1alpha1.SecretKeySelector }
+
+func (m *MockCredentialsSecretReferencer) SetCredentialsSecretReference(r *v1alpha1.SecretKeySelector) {
+	m.Ref = r
+}
+func (m *MockCredentialsSecretReferencer) GetCredentialsSecretReference() *v1alpha1.SecretKeySelector {
+	return m.Ref
+}
+
 var _ Claim = &MockClaim{}
 
 type MockClaim struct {
@@ -145,6 +154,27 @@ func (m *MockManaged) GetObjectKind() schema.ObjectKind {
 
 func (m *MockManaged) DeepCopyObject() runtime.Object {
 	out := &MockManaged{}
+	j, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	json.Unmarshal(j, out)
+	return out
+}
+
+var _ Provider = &MockProvider{}
+
+type MockProvider struct {
+	metav1.ObjectMeta
+	MockCredentialsSecretReferencer
+}
+
+func (m *MockProvider) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (m *MockProvider) DeepCopyObject() runtime.Object {
+	out := &MockProvider{}
 	j, err := json.Marshal(m)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

`Provider` object is used in all calls made to the external providers. Because of that its lifecycle differs from others. Stack who manage Crossplane resources currently have no way of knowing whether an object is a provider unless they import specific infrastructure stack module, which is not practical due to added dependencies.

The case I needed this is that I'm working on a generic configurations stack reconciler and `Provider`s have to be deleted last as opposed to other resources because their deletion fails if `Provider` is gone. However, since it has to be generic, identifying whether a resource is a `Provider` one has to import every infra stack and check the object's `GroupVersionKind`. This interface will make it much easier to identify a `Provider` type resource in a generic way.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml